### PR TITLE
Enhance CI/CD pipeline with Docker support and deployment script for …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+  if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
             registry: ghcr.io
@@ -76,6 +77,7 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Docker image
+  if: github.event_name == 'push'
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,15 @@
-name: .NET and SolidJS CI
+name: CI & Deploy
 
 on:
   push:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+
+permissions:
+  contents: read
+  packages: write  # needed for GHCR push
+  id-token: write
 
 jobs:
   build:
@@ -63,17 +68,48 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image (test only)
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & Push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
-          push: false
-          tags: serving-solid-characters:test-${{ github.sha }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/serving-solid-characters:latest
+            ghcr.io/${{ github.repository_owner }}/serving-solid-characters:${{ github.sha }}
           build-args: |
             BUILD_CONFIGURATION=Release
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository (for compose & scripts)
+        uses: actions/checkout@v4
+
+      - name: Add SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.LINODE_SSH_KEY }}
+
+      - name: Copy compose file & scripts
+        run: |
+          scp -o StrictHostKeyChecking=no docker-compose.prod.yml ${{ secrets.LINODE_USER }}@${{ secrets.LINODE_HOST }}:/opt/serving-solid-characters/docker-compose.yml
+          scp -o StrictHostKeyChecking=no scripts/deploy.sh ${{ secrets.LINODE_USER }}@${{ secrets.LINODE_HOST }}:/opt/serving-solid-characters/deploy.sh
+
+      - name: Deploy over SSH
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.LINODE_USER }}@${{ secrets.LINODE_HOST }} 'chmod +x /opt/serving-solid-characters/deploy.sh && IMAGE_TAG=latest /opt/serving-solid-characters/deploy.sh'
 
       # Optional: Push Docker Image to Registry
       #- name: Login to Docker Registry

--- a/README.md
+++ b/README.md
@@ -101,6 +101,31 @@ ConnectionStrings__work=Server=sqlserver,1433;Database=TestDb;User=sa;Password=P
 ```
 
 Inside containers we serve plain HTTP on port 8080; terminate TLS at your ingress / reverse proxy. Local dev outside Docker still uses HTTPS with your `nethost.pfx`.
+
+### CI/CD Deployment (GitHub Actions -> Linode)
+
+Workflow builds and pushes an image to GHCR on pushes to `main`, then deploys to your Linode via SSH.
+
+Required GitHub secrets:
+| Secret | Description |
+|--------|-------------|
+| LINODE_SSH_KEY | Private key with access to target server |
+| LINODE_HOST | Public IP / hostname of server |
+| LINODE_USER | SSH user (must have docker perms) |
+| (optional) GHCR_TOKEN | If server needs explicit login (usually not needed; PAT with read:packages) |
+
+Server one-time prep (run manually on Linode):
+```
+sudo mkdir -p /opt/serving-solid-characters
+sudo usermod -aG docker $USER # re-login
+```
+
+Deployment script path on server: `/opt/serving-solid-characters/deploy.sh`
+
+To manually redeploy with a specific image tag:
+```
+ssh $LINODE_USER@$LINODE_HOST 'IMAGE_TAG=<sha> /opt/serving-solid-characters/deploy.sh'
+```
 ## ⛏️ Built Using <a name = "built_using"></a>
 
 - [SQL, Dexie]() - Database

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,28 @@
+version: '3.9'
+services:
+  web:
+    image: ghcr.io/${REPO_OWNER:-colehend}/serving-solid-characters:${IMAGE_TAG:-latest}
+    container_name: serving-solid-characters
+    restart: unless-stopped
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      DB_CONNECTION_NAME: work
+      # ConnectionStrings__work: Server=sqlserver,1433;Database=TestDb;User=sa;Password=Passw0rd!;TrustServerCertificate=True;Encrypt=False
+    ports:
+      - "8080:8080"
+    depends_on: []
+
+  # sqlserver:
+  #   image: mcr.microsoft.com/mssql/server:2022-latest
+  #   container_name: mssql
+  #   restart: unless-stopped
+  #   environment:
+  #     ACCEPT_EULA: "Y"
+  #     MSSQL_SA_PASSWORD: "Passw0rd!" # change me
+  #   volumes:
+  #     - mssqldata:/var/opt/mssql
+  #   ports:
+  #     - "1433:1433"
+
+# volumes:
+#   mssqldata:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Variables (with defaults)
+REPO_OWNER=${REPO_OWNER:-colehend}
+IMAGE_TAG=${IMAGE_TAG:-latest}
+APP_DIR=/opt/serving-solid-characters
+COMPOSE_FILE=$APP_DIR/docker-compose.yml
+IMAGE="ghcr.io/${REPO_OWNER}/serving-solid-characters:${IMAGE_TAG}"
+
+echo "Pulling image $IMAGE"
+mkdir -p "$APP_DIR"
+cd "$APP_DIR"
+
+# Login to GHCR if token provided (expect GHCR_TOKEN passed via environment)
+if [[ -n "${GHCR_TOKEN:-}" ]]; then
+  echo "$GHCR_TOKEN" | docker login ghcr.io -u "$REPO_OWNER" --password-stdin
+fi
+
+docker pull "$IMAGE"
+
+# Create/update .env for docker-compose variable substitution
+cat > .env <<EOF
+REPO_OWNER=$REPO_OWNER
+IMAGE_TAG=$IMAGE_TAG
+EOF
+
+echo "Recreating container"
+# Stop old container if exists
+if docker ps -aq -f name=serving-solid-characters >/dev/null; then
+  docker compose -f "$COMPOSE_FILE" down
+fi
+
+docker compose -f "$COMPOSE_FILE" up -d
+
+echo "Deployment complete"


### PR DESCRIPTION
This pull request introduces a CI/CD pipeline to automate building, publishing, and deploying Docker images for the project using GitHub Actions and Linode. The workflow now builds and pushes Docker images to GitHub Container Registry (GHCR) on pushes to `main`, then deploys to a Linode server via SSH using a new deployment script and compose file. The README is updated with deployment instructions and required secrets.

**CI/CD Pipeline & Deployment Automation**

* Updated `.github/workflows/build.yml` to build and push Docker images to GHCR, and added a deploy job that connects to Linode via SSH to copy deployment files and execute the deployment script. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L1-R13) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L66-R113)
* Added `scripts/deploy.sh`, a robust deployment script for pulling the latest image, updating environment variables, and recreating the container using Docker Compose on the server.
* Added `docker-compose.prod.yml` for production deployments, referencing the image in GHCR and supporting environment variable substitution for owner and tag.

**Documentation**

* Updated `README.md` with clear instructions for CI/CD deployment, required GitHub secrets, server setup steps, and manual redeployment commands.