### PR TITLE
Update Docker image references to use fixed repository owner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/serving-solid-characters:latest
-            ghcr.io/${{ github.repository_owner }}/serving-solid-characters:${{ github.sha }}
+            ghcr.io/colehend/serving-solid-characters:latest
+            ghcr.io/colehend/serving-solid-characters:${{ github.sha }}
           build-args: |
             BUILD_CONFIGURATION=Release
           cache-from: type=gha

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   web:
-    image: ghcr.io/${REPO_OWNER:-colehend}/serving-solid-characters:${IMAGE_TAG:-latest}
+    image: ghcr.io/colehend/serving-solid-characters:${IMAGE_TAG:-latest}
     container_name: serving-solid-characters
     restart: unless-stopped
     environment:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,7 +6,7 @@ REPO_OWNER=${REPO_OWNER:-colehend}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 APP_DIR=/opt/serving-solid-characters
 COMPOSE_FILE=$APP_DIR/docker-compose.yml
-IMAGE="ghcr.io/${REPO_OWNER}/serving-solid-characters:${IMAGE_TAG}"
+IMAGE="ghcr.io/colehend/serving-solid-characters:${IMAGE_TAG}"
 
 echo "Pulling image $IMAGE"
 mkdir -p "$APP_DIR"


### PR DESCRIPTION
This pull request updates the image naming and repository references for the Docker build and deployment pipeline. The main change is switching from a dynamic repository owner variable to a hardcoded `colehend` owner for all image tags and references, ensuring consistency across the workflow, compose file, and deployment script.

**Docker image reference updates:**

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L87-R88): Changed the Docker image tags to use `ghcr.io/colehend/serving-solid-characters` instead of dynamically using the repository owner variable.

**Deployment configuration updates:**

* [`docker-compose.prod.yml`](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L4-R4): Updated the image reference for the `web` service to use the hardcoded `colehend` owner rather than the `${REPO_OWNER}` variable.
* [`scripts/deploy.sh`](diffhunk://#diff-37cb4e5e5a1884f59247915193e6246be6df0129ae8e233b8a78c0c91d47dc04L9-R9): Updated the `IMAGE` variable to use the hardcoded `colehend` owner instead of `${REPO_OWNER}`.