### PR TITLE
Refactor Docker image references to use lowercase repository owner an…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      REPO_OWNER_LOWER: ${{ toLower(github.repository_owner) }}
 
     strategy:
       matrix:
@@ -69,7 +71,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-  if: github.event_name == 'push'
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
             registry: ghcr.io
@@ -77,15 +79,15 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Docker image
-  if: github.event_name == 'push'
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
           push: true
           tags: |
-            ghcr.io/colehend/serving-solid-characters:latest
-            ghcr.io/colehend/serving-solid-characters:${{ github.sha }}
+            ghcr.io/${{ env.REPO_OWNER_LOWER }}/serving-solid-characters:latest
+            ghcr.io/${{ env.REPO_OWNER_LOWER }}/serving-solid-characters:${{ github.sha }}
           build-args: |
             BUILD_CONFIGURATION=Release
           cache-from: type=gha

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,7 +1,8 @@
 version: '3.9'
 services:
   web:
-    image: ghcr.io/colehend/serving-solid-characters:${IMAGE_TAG:-latest}
+  # REPO_OWNER expected already lowercase; enforce by transforming before passing if needed
+  image: ghcr.io/${REPO_OWNER:-colehend}/serving-solid-characters:${IMAGE_TAG:-latest}
     container_name: serving-solid-characters
     restart: unless-stopped
     environment:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,10 +3,12 @@ set -euo pipefail
 
 # Variables (with defaults)
 REPO_OWNER=${REPO_OWNER:-colehend}
+# force lowercase to avoid GHCR case-sensitivity issues
+REPO_OWNER=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')
 IMAGE_TAG=${IMAGE_TAG:-latest}
 APP_DIR=/opt/serving-solid-characters
 COMPOSE_FILE=$APP_DIR/docker-compose.yml
-IMAGE="ghcr.io/colehend/serving-solid-characters:${IMAGE_TAG}"
+IMAGE="ghcr.io/${REPO_OWNER}/serving-solid-characters:${IMAGE_TAG}"
 
 echo "Pulling image $IMAGE"
 mkdir -p "$APP_DIR"


### PR DESCRIPTION
This pull request updates how the repository owner is handled throughout the build and deployment process to ensure the owner name is always lowercase, preventing issues with case sensitivity in GitHub Container Registry (GHCR) image references. The changes affect the CI workflow, deployment scripts, and production Docker Compose configuration.

**Container image reference normalization:**

* Updated `.github/workflows/build.yml` to set a `REPO_OWNER_LOWER` environment variable using `toLower(github.repository_owner)` and use it for GHCR image tags, replacing hardcoded owner references. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R17-R18) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L87-R90)
* Modified `docker-compose.prod.yml` to use `${REPO_OWNER:-colehend}` for the image owner, with a note to ensure it's lowercase before passing.
* Changed `scripts/deploy.sh` to force `REPO_OWNER` to lowercase using `tr`, ensuring consistent image naming and preventing registry errors.