### PR TITLE
prodworks

### DIFF
--- a/SharpAnglesTemplate.csproj
+++ b/SharpAnglesTemplate.csproj
@@ -19,6 +19,8 @@
     <Content Remove="$(SpaRoot)**" />
     <None Remove="$(SpaRoot)**" />
     <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
+  <!-- Include data json files -->
+  <Content Update="data/**/*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client/src/shared/customHooks/utility/tools/httpClientObs.ts
+++ b/client/src/shared/customHooks/utility/tools/httpClientObs.ts
@@ -8,7 +8,7 @@ interface HttpConfig {
 }
 
 class HttpClientObs {
-  private server = 'https://192.168.1.100:5000';
+  private server = window.location.origin;
 
   //–– Signals for auth headers and raw token
   private loggedInHeaders: Accessor<Record<string, string>>;

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,8 @@
 version: '3.9'
 services:
   web:
-  # REPO_OWNER expected already lowercase; enforce by transforming before passing if needed
-  image: ghcr.io/${REPO_OWNER:-colehend}/serving-solid-characters:${IMAGE_TAG:-latest}
+    # REPO_OWNER expected already lowercase; enforce by transforming before passing if needed
+    image: ghcr.io/${REPO_OWNER:-colehend}/serving-solid-characters:${IMAGE_TAG:-latest}
     container_name: serving-solid-characters
     restart: unless-stopped
     environment:


### PR DESCRIPTION
This pull request improves the application's production readiness and deployment flexibility, focusing on better proxy handling, response compression, static asset caching, and environment-based configuration. It also enhances the data layer to support flexible JSON data locations and updates the client to use the correct API endpoint. These changes make the app more robust in containerized and cloud environments.

**Production and Deployment Hardening**

* Added response compression (`AddResponseCompression`) for improved API performance, with Gzip configured for fastest compression.
* Configured forwarded headers (`ForwardedHeadersOptions`) to properly handle reverse proxy setups (e.g., Cloudflare), including trusting Docker bridge IPs. [[1]](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bR84-R102) [[2]](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bR16-R19)
* Enhanced Kestrel server configuration to allow HTTP port override via the `PORT` environment variable, supporting container platforms.
* Applied production security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`), HSTS, and conditional HTTPS redirection for local development only.

**Static Asset and SPA Improvements**

* Added cache-control headers to static file responses for improved client-side performance and reduced server load.
* Refined SPA fallback logic: development proxies to Vite/Solid dev server, production serves pre-built assets, and fallback routing is handled by SPA middleware.

**Data Layer Flexibility**

* Updated `DbJsonService` to allow overriding the JSON data root via the `DB_JSON_ROOT` environment variable, with robust fallback logic and logging. [[1]](diffhunk://#diff-ca9e5441b6f6bd3fc9edbda142b1751eebd1df19167cce1651576e9b35ed9d4dL16-R47) [[2]](diffhunk://#diff-ca9e5441b6f6bd3fc9edbda142b1751eebd1df19167cce1651576e9b35ed9d4dL69-R118)
* Ensured that `data/**/*` files are included in publish/output directories for deployment.

**Client API Endpoint Configuration**

* Changed the HTTP client base URL to use `window.location.origin`, ensuring correct API endpoint usage in different environments.