### PR TITLE
Add D&D 5e math utilities and enhance HTTP client streaming

### DIFF
--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/aiHelpers/aiExample.tsx
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/aiHelpers/aiExample.tsx
@@ -1,0 +1,73 @@
+import { createLLM } from "./aiHelpers";
+import { For, Show } from "solid-js";
+/*
+A few things worth considering if you take this further:
+  Abort support — store an AbortController and pass its signal to fetch so users can cancel in-flight requests. 
+Wire it to a "Stop" button that replaces "Send" while loading() is true.
+  Token counting — the messages array grows unbounded. For long conversations, you'll eventually hit context limits. 
+You can trim older messages or summarize them before sending.
+  Retry logic — rate limits (429) and transient server errors (500/503) are common. A simple exponential backoff with 2–3 retries goes a long way.
+  Key safety — never ship API keys in client-side code for production. Proxy through your own backend that attaches the key server-side. 
+For local dev and prototyping, environment variables via import.meta.env are fine.
+*/
+
+function Chat() {
+  let inputRef!: HTMLTextAreaElement;
+  const URL = "https://api.openai.com"; // or your custom endpoint
+  const APIKEY = 'CoolKey'; // or undefined if not needed
+  const llm = createLLM({
+    baseURL: URL,
+    apiKey: APIKEY,
+    model: "gpt-4o",
+    systemPrompt: "You are a concise, helpful assistant.",
+  });
+
+  async function handleSend() {
+    const text = inputRef.value.trim();
+    if (!text || llm.loading()) return;
+    inputRef.value = "";
+    await llm.send(text);
+  }
+
+  return (
+    <div>
+      {/* Message history */}
+      <For each={llm.messages()}>
+        {(msg) => (
+          <Show when={msg.role !== "system"}>
+            <div class={msg.role}>
+              <strong>{msg.role}:</strong> {msg.content}
+            </div>
+          </Show>
+        )}
+      </For>
+
+      {/* Live streaming output */}
+      <Show when={llm.loading()}>
+        <div class="assistant streaming">{llm.output()}</div>
+      </Show>
+
+      {/* Error display */}
+      <Show when={llm.error()}>
+        <div class="error">{llm.error()}</div>
+      </Show>
+
+      {/* Input */}
+      <textarea
+        ref={inputRef}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            handleSend();
+          }
+        }}
+        disabled={llm.loading()}
+        placeholder="Type a message..."
+      />
+      <button onClick={handleSend} disabled={llm.loading()}>
+        Send
+      </button>
+      <button onClick={llm.clear}>Clear</button>
+    </div>
+  );
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/aiHelpers/aiHelpers.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/aiHelpers/aiHelpers.ts
@@ -1,0 +1,195 @@
+// createLLM.ts
+import { createSignal, batch } from "solid-js";
+
+type Message = {
+  role: "system" | "user" | "assistant";
+  content: string;
+};
+/* 
+   How It Works:
+    - messages is a signal holding the full conversation array. Every call to send appends a user message, 
+   fires the request, then appends the assistant reply.
+    - output is a signal that updates on every streamed token — any UI that reads output() will re-render 
+    character by character, giving you the typewriter effect for free via SolidJS's fine-grained reactivity.
+    - loading and error are standard request-state signals.
+    - batch() groups multiple signal writes into one update pass so the UI doesn't flicker between intermediate states.
+*/
+type CreateLLMOptions = {
+  /** Base URL, e.g. "https://api.openai.com" or "http://localhost:11434" */
+  baseURL: string;
+  /** API key (sent as Bearer token) */
+  apiKey?: string;
+  /** Model name, e.g. "gpt-4o", "llama3", "mistral-large-latest" */
+  model: string;
+  /** Optional system prompt prepended to every request */
+  systemPrompt?: string;
+  /** Use streaming (default: true) */
+  stream?: boolean;
+};
+
+export function createLLM(options: CreateLLMOptions) {
+  const [messages, setMessages] = createSignal<Message[]>(
+    options.systemPrompt
+      ? [{ role: "system", content: options.systemPrompt }]
+      : []
+  );
+  const [output, setOutput] = createSignal("");
+  const [loading, setLoading] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const useStream = options.stream ?? true;
+
+  // --- internal: non-streaming fetch ---
+  async function fetchComplete(msgs: Message[]): Promise<string> {
+    const res = await fetch(`${options.baseURL}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(options.apiKey && { Authorization: `Bearer ${options.apiKey}` }),
+      },
+      body: JSON.stringify({
+        model: options.model,
+        messages: msgs,
+        stream: false,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`API ${res.status}: ${body}`);
+    }
+
+    const json = await res.json();
+    return json.choices[0].message.content;
+  }
+
+  // --- internal: streaming fetch ---
+  async function fetchStream(
+    msgs: Message[],
+    onChunk: (text: string) => void
+  ): Promise<string> {
+    const res = await fetch(`${options.baseURL}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(options.apiKey && { Authorization: `Bearer ${options.apiKey}` }),
+      },
+      body: JSON.stringify({
+        model: options.model,
+        messages: msgs,
+        stream: true,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`API ${res.status}: ${body}`);
+    }
+
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let full = "";
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      // SSE lines are separated by double newlines
+      const lines = buffer.split("\n");
+      // Keep the last (possibly incomplete) line in the buffer
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith("data: ")) continue;
+
+        const payload = trimmed.slice(6); // strip "data: "
+        if (payload === "[DONE]") break;
+
+        try {
+          const chunk = JSON.parse(payload);
+          const token = chunk.choices?.[0]?.delta?.content ?? "";
+          if (token) {
+            full += token;
+            onChunk(full); // pass the accumulated text so far
+          }
+        } catch {
+          // ignore malformed chunks
+        }
+      }
+    }
+
+    return full;
+  }
+
+  // --- public: send a message ---
+  async function send(userMessage: string): Promise<string> {
+    batch(() => {
+      setError(null);
+      setLoading(true);
+      setOutput("");
+    });
+
+    // Append the user message to history
+    const updated: Message[] = [
+      ...messages(),
+      { role: "user", content: userMessage },
+    ];
+    setMessages(updated);
+
+    try {
+      let result: string;
+
+      if (useStream) {
+        result = await fetchStream(updated, (soFar) => setOutput(soFar));
+      } else {
+        result = await fetchComplete(updated);
+        setOutput(result);
+      }
+
+      // Append assistant reply to history
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: result },
+      ]);
+
+      return result;
+    } catch (e: any) {
+      setError(e.message ?? "Unknown error");
+      throw e;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // --- public: reset conversation ---
+  function clear() {
+    batch(() => {
+      setMessages(
+        options.systemPrompt
+          ? [{ role: "system", content: options.systemPrompt }]
+          : []
+      );
+      setOutput("");
+      setError(null);
+    });
+  }
+
+  return {
+    /** The current (or in-progress) assistant output */
+    output,
+    /** Full message history */
+    messages,
+    /** Whether a request is in flight */
+    loading,
+    /** Last error message, or null */
+    error,
+    /** Send a user message and get a response */
+    send,
+    /** Reset the conversation */
+    clear,
+  };
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dndMath.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dndMath.ts
@@ -1,0 +1,794 @@
+/**
+ * D&D 5e Math Utilities for DPR Calculation
+*/
+export function getProficiencyBonus(level: number): number {
+    return Math.ceil(level / 4) + 1;
+}
+
+/**
+ * Calculate the ability modifier for a given ability score.
+ */
+export function getAbilityModifier(score: number): number {
+    return Math.floor((score - 10) / 2);
+}
+
+/**
+ * D&D 5e DPR (Damage Per Round) Calculator
+ *
+ * Based on LudicSavant's DPR Calculator v2.0 documentation.
+ * Implements hit/save probability, damage averaging, and full DPR computation
+ * including advantage/disadvantage, Elven Accuracy, Halfling Luck,
+ * bonus/penalty dice, critical hits, Great Weapon Fighting, Elemental Adept,
+ * once-per-turn effects, power attacks, and save-based damage.
+ */
+
+// ─── Damage Calculation Types ───────────────────────────────────────────────────────────────────
+
+/** Represents a group of identical dice, e.g. 2d6 */
+export interface DiceGroup {
+  count: number;
+  sides: number; // 4, 6, 8, 10, or 12
+}
+
+/** Options that modify how damage dice are rolled */
+export interface DiceModifiers {
+  /** Great Weapon Fighting: reroll 1s and 2s */
+  greatWeaponFighting?: boolean;
+  /** Elemental Adept: treat 1s as 2s */
+  elementalAdept?: boolean;
+}
+
+/** Describes one attack's hit parameters */
+export interface AttackParams {
+  attackBonus: number;
+  targetAC: number;
+  advantageMode: "normal" | "advantage" | "disadvantage";
+  elvenAccuracy?: boolean;
+  halflingLuck?: boolean;
+  critThreshold?: number; // default 20; Champion fighters get 19 or 18
+}
+
+/** Describes the damage dealt by one attack */
+export interface AttackDamage {
+  /** Dice rolled on a normal hit */
+  damageDice: DiceGroup[];
+  /** Static bonus added to damage (e.g. ability modifier) */
+  damageBonus: number;
+  /** Additional dice rolled only on a critical hit (e.g. Brutal Critical) */
+  critBonusDice?: DiceGroup[];
+  /** Modifiers affecting how dice are rolled */
+  diceModifiers?: DiceModifiers;
+}
+
+/** A full attack action entry for DPR computation */
+export interface AttackEntry {
+  attack: AttackParams;
+  damage: AttackDamage;
+  numberOfAttacks: number;
+}
+
+/** Bonus dice added/subtracted from the d20 roll (e.g. Bless = 1d4, Bane = -1d4) */
+export interface BonusDie {
+  sides: number; // e.g. 4 for Bless
+  penalty?: boolean; // true if this is subtracted (Bane, Cutting Words, etc.)
+}
+
+/** Once-per-turn damage like Sneak Attack or Divine Strike */
+export interface OncePerTurnDamage {
+  damageDice: DiceGroup[];
+  damageBonus: number;
+  diceModifiers?: DiceModifiers;
+}
+
+/** Parameters for a save-based damage effect */
+export interface SaveEffectParams {
+  saveDC: number;
+  targetSaveBonus: number;
+  /** Damage dice on a failed save */
+  damageDice: DiceGroup[];
+  damageBonus: number;
+  diceModifiers?: DiceModifiers;
+  saveType: "no_save" | "save_negates" | "save_half";
+  evasion?: boolean;
+  numberOfTargets?: number;
+}
+
+/** Complete result of a DPR calculation */
+export interface DPRResult {
+  /** Total expected damage per round */
+  dpr: number;
+  /** Probability of hitting at least once */
+  hitChance: number;
+  /** Probability of a critical hit per attack */
+  critChance: number;
+  /** Average damage on a normal hit (per attack) */
+  averageDamageOnHit: number;
+  /** Average damage on a critical hit (per attack) */
+  averageDamageOnCrit: number;
+}
+
+// ─── Core Probability Functions ──────────────────────────────────────────────
+
+/**
+ * Basic probability of hitting a given AC with a given attack bonus.
+ * P(hit) = (21 - AC + attackBonus) / 20, clamped to [0.05, 0.95].
+ * A natural 20 always hits (min 0.05), a natural 1 always misses (max 0.95).
+ */
+export function baseHitProbability(
+  attackBonus: number,
+  targetAC: number
+): number {
+  const raw = (21 - targetAC + attackBonus) / 20;
+  return Math.min(0.95, Math.max(0.05, raw));
+}
+
+/**
+ * Basic probability of a target failing a saving throw.
+ * P(fail) = 1 - P(save), where P(save) = (21 - DC + saveBonus) / 20, clamped to [0, 1].
+ * No critical effects on saves, so thresholds are 0 and 1.
+ */
+export function baseSaveFailProbability(
+  saveDC: number,
+  targetSaveBonus: number
+): number {
+  const pSave = (21 - saveDC + targetSaveBonus) / 20;
+  return 1 - Math.min(1, Math.max(0, pSave));
+}
+
+/**
+ * Apply advantage, disadvantage, or Elven Accuracy to a base probability.
+ *
+ * - Advantage:       P_adv = 1 - (1 - P)^2
+ * - Disadvantage:    P_dis = P^2
+ * - Elven Accuracy:  P_ea  = 1 - (1 - P)^3  (super-advantage with 3 dice)
+ */
+export function applyAdvantageMode(
+  p: number,
+  mode: "normal" | "advantage" | "disadvantage",
+  elvenAccuracy: boolean = false
+): number {
+  switch (mode) {
+    case "advantage":
+      if (elvenAccuracy) {
+        // Elven Accuracy: roll 3 dice, take highest
+        return 1 - Math.pow(1 - p, 3);
+      }
+      return 1 - Math.pow(1 - p, 2);
+    case "disadvantage":
+      return Math.pow(p, 2);
+    default:
+      return p;
+  }
+}
+
+/**
+ * Apply Halfling Luck to a probability.
+ *
+ * Halfling Lucky: reroll one d20 if it shows a 1.
+ * For attacks, a nat 1 is always a miss, so the reroll condition is
+ * always within the failure range.
+ *
+ * Normal:       P_luck = P + (1/20)(1 - 1/20) * P_base_no_luck_adjustment
+ * Simplified:   P_luck = P + (1/20) * P   (since rolling a 1 then succeeding on reroll)
+ *
+ * More precisely, for attacks:
+ *   P_luck_normal = P + (1/20) * P
+ *   P_luck_adv    = P_adv + 2*(1/20)*(1-1/20) * (1-P) * P  [approximation]
+ *   P_luck_dis    = P_dis + (1/20) * P * (2*P - P^2) ... complex
+ *
+ * We use the simplified approach: the probability of rolling a 1 on
+ * any relevant d20, times the probability of succeeding on the reroll.
+ */
+export function applyHalflingLuck(
+  baseP: number,
+  mode: "normal" | "advantage" | "disadvantage",
+  elvenAccuracy: boolean = false
+): number {
+  const pRerollSuccess = baseP; // probability of succeeding on the reroll
+  const pRollOne = 1 / 20;
+
+  switch (mode) {
+    case "normal":
+      // P + (1/20) * P = P * (1 + 1/20) ... but that's not quite right.
+      // Correct: P_luck = P + pRollOne * (1 - P_without_luck_for_that_roll) * ... 
+      // Simplified per the doc: succeed normally OR (roll a 1 AND succeed on reroll)
+      // For normal: P_luck = P + (1/20) * baseHitP
+      // But the "P" already includes the nat-1-is-a-miss floor.
+      // The bonus is: probability of rolling exactly a 1 (which is always a miss)
+      // times probability the reroll hits.
+      return baseP + pRollOne * pRerollSuccess;
+
+    case "advantage": {
+      if (elvenAccuracy) {
+        // 3 dice: probability that at least one d20 is a 1 and all would otherwise miss,
+        // times reroll success. This gets complex; approximate:
+        const pFail = 1 - baseP;
+        const pAllFail = Math.pow(pFail, 3);
+        const pAllFailNoOnes = Math.pow(pFail - pRollOne, 3);
+        // Probability at least one 1 among failures:
+        const pAtLeastOneOneAmongFailures = pAllFail - pAllFailNoOnes;
+        return 1 - pAllFail + pAtLeastOneOneAmongFailures * pRerollSuccess;
+      }
+      // 2 dice advantage with halfling luck
+      const pFail = 1 - baseP;
+      const pAllFail = Math.pow(pFail, 2);
+      const pAllFailNoOnes = Math.pow(pFail - pRollOne, 2);
+      const pAtLeastOneOne = pAllFail - pAllFailNoOnes;
+      return 1 - pAllFail + pAtLeastOneOne * pRerollSuccess;
+    }
+
+    case "disadvantage": {
+      // Both dice must succeed. Halfling luck lets you reroll one 1.
+      // P_dis_luck = P^2 + (for each die: P(that die is 1) * P(other die succeeds) * P(reroll succeeds))
+      // Simplified: you need both to succeed; if one is a 1, reroll it
+      const pBothSucceed = baseP * baseP;
+      // P(exactly one die is 1, other succeeds) * P(reroll succeeds)
+      // P(die is 1) = 1/20, P(other succeeds) = baseP
+      // Two ways this can happen (die1=1 or die2=1), but halfling luck only rerolls one
+      const bonus = 2 * pRollOne * baseP * pRerollSuccess -
+        pRollOne * pRollOne * baseP * pRerollSuccess; // subtract double-count
+      return pBothSucceed + bonus;
+    }
+  }
+}
+
+/**
+ * Compute the full hit probability for an attack, incorporating
+ * advantage/disadvantage, Elven Accuracy, and Halfling Luck.
+ */
+export function hitProbability(params: AttackParams): number {
+  const baseP = baseHitProbability(params.attackBonus, params.targetAC);
+
+  if (params.halflingLuck) {
+    return applyHalflingLuck(
+      baseP,
+      params.advantageMode,
+      params.elvenAccuracy ?? false
+    );
+  }
+
+  return applyAdvantageMode(
+    baseP,
+    params.advantageMode,
+    params.elvenAccuracy ?? false
+  );
+}
+
+/**
+ * Compute the probability of scoring a critical hit.
+ *
+ * The crit probability is the probability of rolling >= critThreshold on
+ * the d20 itself (no attack bonus). This is equivalent to
+ * P(hit AC = critThreshold, attackBonus = 0), but with thresholds [0, 1]
+ * instead of [0.05, 0.95] since we don't apply the nat-1/nat-20 override here—
+ * the critical range IS the nat-20 override.
+ */
+export function critProbability(params: AttackParams): number {
+  const threshold = params.critThreshold ?? 20;
+  // Number of faces that crit: 20 - threshold + 1
+  const baseP = (21 - threshold) / 20;
+
+  if (params.halflingLuck) {
+    return applyHalflingLuck(
+      baseP,
+      params.advantageMode,
+      params.elvenAccuracy ?? false
+    );
+  }
+
+  return applyAdvantageMode(
+    baseP,
+    params.advantageMode,
+    params.elvenAccuracy ?? false
+  );
+}
+
+// ─── Bonus/Penalty Dice (Bless, Bane, etc.) ─────────────────────────────────
+
+/**
+ * Compute a probability distribution for a set of bonus/penalty dice.
+ * Returns a Map from total modifier value to its probability.
+ *
+ * For example, Bless (1d4) produces: {1: 0.25, 2: 0.25, 3: 0.25, 4: 0.25}
+ * Bane (-1d4) produces: {-1: 0.25, -2: 0.25, -3: 0.25, -4: 0.25}
+ */
+export function bonusDiceDistribution(
+  dice: BonusDie[]
+): Map<number, number> {
+  let dist = new Map<number, number>();
+  dist.set(0, 1);
+
+  for (const die of dice) {
+    const newDist = new Map<number, number>();
+    const sign = die.penalty ? -1 : 1;
+    const pPerFace = 1 / die.sides;
+
+    for (const [existingVal, existingProb] of dist) {
+      for (let face = 1; face <= die.sides; face++) {
+        const newVal = existingVal + sign * face;
+        const newProb = (newDist.get(newVal) ?? 0) + existingProb * pPerFace;
+        newDist.set(newVal, newProb);
+      }
+    }
+
+    dist = newDist;
+  }
+
+  return dist;
+}
+
+/**
+ * Compute hit probability incorporating bonus/penalty dice (like Bless/Bane).
+ *
+ * P(hit with bonus dice) = Σ P(bonus = b) * H(AC, attack + b)
+ *
+ * where H computes the full hit probability (with advantage, etc.)
+ */
+export function hitProbabilityWithBonusDice(
+  params: AttackParams,
+  bonusDice: BonusDie[]
+): number {
+  if (bonusDice.length === 0) return hitProbability(params);
+
+  const dist = bonusDiceDistribution(bonusDice);
+  let totalP = 0;
+
+  for (const [bonus, prob] of dist) {
+    const modifiedParams: AttackParams = {
+      ...params,
+      attackBonus: params.attackBonus + bonus,
+    };
+    totalP += prob * hitProbability(modifiedParams);
+  }
+
+  return totalP;
+}
+
+// ─── Damage Computation ──────────────────────────────────────────────────────
+
+/**
+ * Average value of a single dN: (N + 1) / 2
+ */
+export function averageDie(sides: number): number {
+  return (sides + 1) / 2;
+}
+
+/**
+ * Average value of a single die with Great Weapon Fighting (reroll 1s and 2s).
+ *
+ * For a dN: (avg(dN) + avg(dN) + 3 + 4 + ... + N) / N
+ * i.e., faces 1 and 2 each produce the average of a fresh dN roll.
+ */
+export function averageDieGWF(sides: number): number {
+  const normalAvg = averageDie(sides);
+  let sum = 2 * normalAvg; // faces 1 and 2 each reroll to normal average
+  for (let face = 3; face <= sides; face++) {
+    sum += face;
+  }
+  return sum / sides;
+}
+
+/**
+ * Average value of a single die with Elemental Adept (treat 1s as 2s).
+ *
+ * For a dN: (2 + 2 + 3 + 4 + ... + N) / N
+ */
+export function averageDieElementalAdept(sides: number): number {
+  let sum = 2; // face 1 becomes 2
+  for (let face = 2; face <= sides; face++) {
+    sum += face;
+  }
+  return sum / sides;
+}
+
+/**
+ * Average value of a single die with both GWF and Elemental Adept.
+ *
+ * Face 1: reroll with Elemental Adept → averageDieElementalAdept(N)
+ * Face 2: reroll with Elemental Adept → averageDieElementalAdept(N)
+ * Faces 3+: face value
+ */
+export function averageDieGWFAndEA(sides: number): number {
+  const eaAvg = averageDieElementalAdept(sides);
+  let sum = 2 * eaAvg; // faces 1 and 2 reroll to EA average
+  for (let face = 3; face <= sides; face++) {
+    sum += face;
+  }
+  return sum / sides;
+}
+
+/**
+ * Compute the average damage for a set of dice groups with modifiers.
+ */
+export function averageDamageFromDice(
+  diceGroups: DiceGroup[],
+  modifiers?: DiceModifiers
+): number {
+  let total = 0;
+  const gwf = modifiers?.greatWeaponFighting ?? false;
+  const ea = modifiers?.elementalAdept ?? false;
+
+  for (const group of diceGroups) {
+    let avg: number;
+    if (gwf && ea) {
+      avg = averageDieGWFAndEA(group.sides);
+    } else if (gwf) {
+      avg = averageDieGWF(group.sides);
+    } else if (ea) {
+      avg = averageDieElementalAdept(group.sides);
+    } else {
+      avg = averageDie(group.sides);
+    }
+    total += group.count * avg;
+  }
+
+  return total;
+}
+
+/**
+ * Compute average damage on a normal hit.
+ */
+export function damageOnHit(damage: AttackDamage): number {
+  return (
+    averageDamageFromDice(damage.damageDice, damage.diceModifiers) +
+    damage.damageBonus
+  );
+}
+
+/**
+ * Compute average damage on a critical hit.
+ * Critical hits double all damage dice (but not static bonuses).
+ * Additional crit-only dice (like Brutal Critical) are also added.
+ */
+export function damageOnCrit(damage: AttackDamage): number {
+  // Double the normal dice
+  const doubledDice: DiceGroup[] = damage.damageDice.map((g) => ({
+    count: g.count * 2,
+    sides: g.sides,
+  }));
+
+  let total = averageDamageFromDice(doubledDice, damage.diceModifiers);
+
+  // Add crit-only bonus dice (these are NOT doubled — they're already the extra dice)
+  if (damage.critBonusDice) {
+    total += averageDamageFromDice(damage.critBonusDice, damage.diceModifiers);
+  }
+
+  return total + damage.damageBonus;
+}
+
+// ─── DPR: Attack Rolls ───────────────────────────────────────────────────────
+
+/**
+ * Compute basic DPR for a single attack.
+ *
+ * E(damage) = (P - C) × DPH + C × DPC
+ *
+ * where P = probability of hitting, C = probability of critting,
+ * DPH = damage on hit, DPC = damage on crit.
+ *
+ * Note: (P - C) is the probability of a regular (non-crit) hit.
+ */
+export function singleAttackDPR(
+  attack: AttackParams,
+  damage: AttackDamage
+): number {
+  const P = hitProbability(attack);
+  const C = critProbability(attack);
+  const DPH = damageOnHit(damage);
+  const DPC = damageOnCrit(damage);
+
+  return (P - C) * DPH + C * DPC;
+}
+
+/**
+ * Compute full DPR result for a single attack.
+ */
+export function singleAttackDPRResult(
+  attack: AttackParams,
+  damage: AttackDamage
+): DPRResult {
+  const P = hitProbability(attack);
+  const C = critProbability(attack);
+  const DPH = damageOnHit(damage);
+  const DPC = damageOnCrit(damage);
+
+  return {
+    dpr: (P - C) * DPH + C * DPC,
+    hitChance: P,
+    critChance: C,
+    averageDamageOnHit: DPH,
+    averageDamageOnCrit: DPC,
+  };
+}
+
+/**
+ * Compute DPR for multiple attacks in a round (just sums them up).
+ * For N identical attacks, multiply by N.
+ */
+export function multiAttackDPR(entries: AttackEntry[]): number {
+  let total = 0;
+  for (const entry of entries) {
+    total += singleAttackDPR(entry.attack, entry.damage) * entry.numberOfAttacks;
+  }
+  return total;
+}
+
+// ─── Once-Per-Turn Effects (Sneak Attack, Divine Strike, etc.) ────────────────
+
+/**
+ * Compute the probability of landing at least one hit in a set of attacks.
+ *
+ * P(at least one hit) = 1 - Π(1 - P_i) for each attack i.
+ */
+export function probabilityOfAtLeastOneHit(entries: AttackEntry[]): number {
+  let pAllMiss = 1;
+  for (const entry of entries) {
+    const P = hitProbability(entry.attack);
+    pAllMiss *= Math.pow(1 - P, entry.numberOfAttacks);
+  }
+  return 1 - pAllMiss;
+}
+
+/**
+ * Compute the probability of at least one critical among all attacks.
+ *
+ * P(at least one crit) = 1 - Π(1 - C_i) for each attack i.
+ */
+export function probabilityOfAtLeastOneCrit(entries: AttackEntry[]): number {
+  let pNoCrit = 1;
+  for (const entry of entries) {
+    const C = critProbability(entry.attack);
+    pNoCrit *= Math.pow(1 - C, entry.numberOfAttacks);
+  }
+  return 1 - pNoCrit;
+}
+
+/**
+ * Compute the additional DPR from a once-per-turn effect (like Sneak Attack).
+ *
+ * Assumes the effect triggers on the first hit landed. The calculation
+ * splits into regular hits and crit hits:
+ *
+ * Additional DPR =
+ *   P(at least one hit) × DS          (base once-per-turn damage)
+ * + P(first hit is a crit) × DSC      (extra crit dice for the effect)
+ *
+ * where DS is the average once-per-turn damage and DSC is the average
+ * of the once-per-turn damage dice only (extra rolled on crit, no static bonus).
+ *
+ * For simplicity, P(first hit is crit | at least one hit) ≈ C/P for the
+ * first attack group weighted by hit probability.
+ */
+export function oncePerTurnDPR(
+  entries: AttackEntry[],
+  oncePerTurn: OncePerTurnDamage
+): number {
+  const pAtLeastOneHit = probabilityOfAtLeastOneHit(entries);
+  if (pAtLeastOneHit === 0) return 0;
+
+  const DS =
+    averageDamageFromDice(oncePerTurn.damageDice, oncePerTurn.diceModifiers) +
+    oncePerTurn.damageBonus;
+
+  // DSC: just the dice portion (doubled for crit, minus the normal dice = extra dice avg)
+  const DSC = averageDamageFromDice(
+    oncePerTurn.damageDice,
+    oncePerTurn.diceModifiers
+  );
+
+  // Compute P(first hit is a crit) using the doc's approach:
+  // For each attack group, compute contribution to "first hit is crit"
+  // P(first hit is crit) = Σ_groups [ P(no hits before this group) × P(≥1 hit in group) × (C/P) ]
+  let pFirstHitIsCrit = 0;
+  let pNoHitsSoFar = 1;
+
+  for (const entry of entries) {
+    const P = hitProbability(entry.attack);
+    const C = critProbability(entry.attack);
+    if (P === 0) continue;
+
+    const pAllMissInGroup = Math.pow(1 - P, entry.numberOfAttacks);
+    const pAtLeastOneHitInGroup = 1 - pAllMissInGroup;
+
+    // Given at least one hit in this group, probability that first hit is a crit
+    // approximated as C/P (proportion of hits that are crits)
+    pFirstHitIsCrit += pNoHitsSoFar * pAtLeastOneHitInGroup * (C / P);
+
+    pNoHitsSoFar *= pAllMissInGroup;
+  }
+
+  // Once-per-turn damage:
+  // = P(at least one hit) × DS + P(first hit is crit) × DSC
+  return pAtLeastOneHit * DS + pFirstHitIsCrit * DSC;
+}
+
+// ─── Power Attacks (Sharpshooter / Great Weapon Master) ──────────────────────
+
+/**
+ * Apply the -5/+10 power attack option (Sharpshooter or GWM).
+ * Subtracts 5 from attack bonus, adds 10 to damage bonus.
+ */
+export function applyPowerAttack(
+  attack: AttackParams,
+  damage: AttackDamage
+): { attack: AttackParams; damage: AttackDamage } {
+  return {
+    attack: {
+      ...attack,
+      attackBonus: attack.attackBonus - 5,
+    },
+    damage: {
+      ...damage,
+      damageBonus: damage.damageBonus + 10,
+    },
+  };
+}
+
+// ─── GWM Crit Bonus Action ───────────────────────────────────────────────────
+
+/**
+ * Compute additional DPR from GWM's crit bonus action attack.
+ *
+ * If you crit on any regular attack, you can make a bonus action attack.
+ * This replaces your normal bonus action, so the net gain is:
+ *   P(at least one crit) × (damage from GWM bonus attack - damage from normal bonus action)
+ *
+ * @param mainAttacks - The main (non-bonus-action) attacks
+ * @param gwmBonusAttack - The single bonus attack granted by GWM crit
+ * @param normalBonusActionDPR - DPR from whatever the normal bonus action would be (0 if none)
+ */
+export function gwmCritBonusDPR(
+  mainAttacks: AttackEntry[],
+  gwmBonusAttack: { attack: AttackParams; damage: AttackDamage },
+  normalBonusActionDPR: number = 0
+): number {
+  const pAtLeastOneCrit = probabilityOfAtLeastOneCrit(mainAttacks);
+  const gwmBonusDPR = singleAttackDPR(
+    gwmBonusAttack.attack,
+    gwmBonusAttack.damage
+  );
+
+  // Only beneficial if GWM bonus exceeds normal bonus action
+  const netGain = gwmBonusDPR - normalBonusActionDPR;
+  if (netGain <= 0) return 0;
+
+  return pAtLeastOneCrit * netGain;
+}
+
+// ─── DPR: Save Effects ───────────────────────────────────────────────────────
+
+/**
+ * Compute the half-damage value for save effects, accounting for D&D's
+ * round-down rule.
+ *
+ * In most cases: halfDamage = DPH / 2 - 0.25
+ * This is because odd damage results (which lose 0.5 when halved and floored)
+ * occur exactly half the time, so on average you lose 0.25.
+ */
+export function halfDamage(fullDamage: number): number {
+  return fullDamage / 2 - 0.25;
+}
+
+/**
+ * Compute DPR for a save-based effect.
+ *
+ * E(damage) = F × DOF + (1 - F) × DOS
+ *
+ * where F = probability target fails save, DOF = damage on fail, DOS = damage on save.
+ */
+export function saveEffectDPR(params: SaveEffectParams): number {
+  const F = baseSaveFailProbability(params.saveDC, params.targetSaveBonus);
+  const fullDmg =
+    averageDamageFromDice(params.damageDice, params.diceModifiers) +
+    params.damageBonus;
+  const halfDmg = halfDamage(fullDmg);
+  const targets = params.numberOfTargets ?? 1;
+
+  let DOF: number; // damage on failed save
+  let DOS: number; // damage on successful save
+
+  switch (params.saveType) {
+    case "no_save":
+      DOF = fullDmg;
+      DOS = fullDmg;
+      break;
+    case "save_negates":
+      DOF = fullDmg;
+      DOS = 0;
+      break;
+    case "save_half":
+      if (params.evasion) {
+        // Evasion: no damage on save, half damage on fail
+        DOF = halfDmg;
+        DOS = 0;
+      } else {
+        // Normal: half damage on save, full damage on fail
+        DOF = fullDmg;
+        DOS = halfDmg;
+      }
+      break;
+  }
+
+  return (F * DOF + (1 - F) * DOS) * targets;
+}
+
+// ─── Utility: Min/Max Damage ─────────────────────────────────────────────────
+
+/**
+ * Compute minimum possible damage from a set of dice + bonus.
+ * Min of each die is 1 (or 2 with Elemental Adept).
+ */
+export function minDamage(
+  diceGroups: DiceGroup[],
+  bonus: number,
+  elementalAdept: boolean = false
+): number {
+  let total = bonus;
+  const minPerDie = elementalAdept ? 2 : 1;
+  for (const group of diceGroups) {
+    total += group.count * minPerDie;
+  }
+  return total;
+}
+
+/**
+ * Compute maximum possible damage from a set of dice + bonus.
+ */
+export function maxDamage(diceGroups: DiceGroup[], bonus: number): number {
+  let total = bonus;
+  for (const group of diceGroups) {
+    total += group.count * group.sides;
+  }
+  return total;
+}
+
+// ─── Full Round DPR Calculator ───────────────────────────────────────────────
+
+export interface FullRoundParams {
+  /** Main action attacks */
+  attacks: AttackEntry[];
+  /** Optional bonus action attacks (separate from main attacks) */
+  bonusActionAttacks?: AttackEntry[];
+  /** Once-per-turn damage (e.g. Sneak Attack) applied across all attacks */
+  oncePerTurn?: OncePerTurnDamage;
+  /** Save-based effects (e.g. a spell's save component) */
+  saveEffects?: SaveEffectParams[];
+}
+
+/**
+ * Compute total DPR for a full round, combining:
+ * - Multiple attack action attacks
+ * - Bonus action attacks
+ * - Once-per-turn effects
+ * - Save-based damage effects
+ */
+export function fullRoundDPR(params: FullRoundParams): number {
+  let total = 0;
+
+  // Attack action DPR
+  total += multiAttackDPR(params.attacks);
+
+  // Bonus action attacks DPR
+  if (params.bonusActionAttacks) {
+    total += multiAttackDPR(params.bonusActionAttacks);
+  }
+
+  // Once-per-turn effects
+  if (params.oncePerTurn) {
+    const allAttacks = [
+      ...params.attacks,
+      ...(params.bonusActionAttacks ?? []),
+    ];
+    total += oncePerTurnDPR(allAttacks, params.oncePerTurn);
+  }
+
+  // Save effects
+  if (params.saveEffects) {
+    for (const effect of params.saveEffects) {
+      total += saveEffectDPR(effect);
+    }
+  }
+
+  return total;
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/downloadObjectAsJson.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/downloadObjectAsJson.ts
@@ -2,12 +2,8 @@ import { Trade } from "../../../../models/trade.model";
 
 export function downloadObjectAsJson(data: Trade, filename: string): void {
   const jsonString = JSON.stringify(data, null, 2); // Pretty-print with 2 spaces
-
-  console.log("JsonString",jsonString);
     
   const blob = new Blob([jsonString], { type: 'application/json' });
-
-  console.log("blob",blob);
     
   const url = URL.createObjectURL(blob);
   

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.context.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.context.ts
@@ -1,0 +1,93 @@
+import {
+	DnDConfig,
+	DnDInstance,
+	DndPayload,
+	DragState,
+	DraggableBinding,
+	DropzoneBinding,
+	SortablePlacement,
+} from './models';
+import { createPreviewManager } from './createDnD.preview';
+
+export type DraggableRecord<Payload extends DndPayload> = {
+	element: HTMLElement;
+	getBinding: () => DraggableBinding<Payload>;
+	pointerDown: (event: PointerEvent) => void;
+};
+
+export type DropzoneRecord<Payload extends DndPayload> = {
+	element: HTMLElement;
+	getBinding: () => DropzoneBinding<Payload>;
+	pointerEnter: (event: PointerEvent) => void;
+	pointerLeave: () => void;
+};
+
+export type PendingDrag<Payload extends DndPayload> = {
+	startX: number;
+	startY: number;
+	element: HTMLElement;
+	binding: DraggableBinding<Payload>;
+	payload: Payload;
+};
+
+export type DnDMutableState<Payload extends DndPayload> = {
+	activeDrag: DragState<Payload> | null;
+	activeDraggable: HTMLElement | null;
+	hoveredDropzone: HTMLElement | null;
+	hoveredPlacement: SortablePlacement | undefined;
+	pendingDrag: PendingDrag<Payload> | null;
+	globalListenersActive: boolean;
+};
+
+export type DnDContext<Payload extends DndPayload> = {
+	config: DnDConfig<Payload>;
+	classes: {
+		activeClassName: string;
+		overClassName: string;
+		insertBeforeClassName: string;
+		insertAfterClassName: string;
+	};
+	dragThreshold: number;
+	preview: ReturnType<typeof createPreviewManager>;
+	draggables: Map<HTMLElement, DraggableRecord<Payload>>;
+	dropzones: Map<HTMLElement, DropzoneRecord<Payload>>;
+	state: DnDMutableState<Payload>;
+};
+
+export type DndDraggableDirective<Payload extends DndPayload> =
+	DnDInstance<Payload>['dndDraggable'];
+export type DndDropzoneDirective<Payload extends DndPayload> =
+	DnDInstance<Payload>['dndDropzone'];
+
+export function createDnDContext<Payload extends DndPayload>(
+	config: DnDConfig<Payload>,
+): DnDContext<Payload> {
+	const activeClassName = config.activeClassName ?? 'dnd-active';
+	const overClassName = config.overClassName ?? 'dnd-over';
+	const previewClassName = config.previewClassName ?? 'dnd-preview';
+	const insertBeforeClassName =
+		config.insertBeforeClassName ?? 'dnd-insert-before';
+	const insertAfterClassName = config.insertAfterClassName ?? 'dnd-insert-after';
+
+	return {
+		config,
+		classes: {
+			activeClassName,
+			overClassName,
+			insertBeforeClassName,
+			insertAfterClassName,
+		},
+		dragThreshold: config.dragThreshold ?? 5,
+		preview: createPreviewManager(previewClassName, config.previewZIndex),
+		draggables: new Map(),
+		dropzones: new Map(),
+		state: {
+			activeDrag: null,
+			activeDraggable: null,
+			hoveredDropzone: null,
+			hoveredPlacement: undefined,
+			pendingDrag: null,
+			globalListenersActive: false,
+		},
+	};
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.destroy.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.destroy.ts
@@ -1,0 +1,37 @@
+import { DndPayload } from './models';
+import { DnDContext } from './createDnD.context';
+import { EventController } from './createDnD.events';
+import { cleanupDraggableElement } from './createDnD.draggable';
+import { cleanupDropzoneElement } from './createDnD.dropzone';
+
+export function createDestroy<Payload extends DndPayload>(
+	context: DnDContext<Payload>,
+	events: EventController<Payload>,
+) {
+	const { draggables, dropzones, classes } = context;
+
+	return () => {
+		events.resetDragState();
+
+		for (const record of draggables.values()) {
+			cleanupDraggableElement(
+				record.element,
+				record.pointerDown,
+				classes.activeClassName,
+			);
+		}
+
+		for (const record of dropzones.values()) {
+			cleanupDropzoneElement(
+				record.element,
+				record.pointerEnter,
+				record.pointerLeave,
+				events.removePlacementClasses,
+				classes.overClassName,
+			);
+		}
+
+		draggables.clear();
+		dropzones.clear();
+	};
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.draggable.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.draggable.ts
@@ -1,0 +1,64 @@
+import { getOwner, onCleanup } from 'solid-js';
+import { DndPayload } from './models';
+import { DnDContext, DndDraggableDirective } from './createDnD.context';
+import { EventController } from './createDnD.events';
+
+export function createDraggableDirective<Payload extends DndPayload>(
+	context: DnDContext<Payload>,
+	events: EventController<Payload>,
+): DndDraggableDirective<Payload> {
+	const { state, draggables, classes, dragThreshold } = context;
+
+	return (element, accessor) => {
+		element.style.touchAction = 'none';
+		element.setAttribute('aria-roledescription', 'draggable');
+		element.setAttribute('aria-grabbed', 'false');
+
+		const pointerDown = (event: PointerEvent) => {
+			event.preventDefault();
+			const binding = accessor();
+
+			if (!binding || !binding.id || binding.disabled) return;
+			const payload = binding.getPayload?.();
+			if (!payload) return;
+
+			state.pendingDrag = {
+				startX: event.clientX,
+				startY: event.clientY,
+				element,
+				binding,
+				payload,
+			};
+
+			events.addGlobalListeners();
+			if (dragThreshold <= 0) {
+				events.activateDrag(state.pendingDrag, event);
+			}
+		};
+
+		element.addEventListener('pointerdown', pointerDown);
+		draggables.set(element, { element, getBinding: accessor, pointerDown });
+
+		if (getOwner()) {
+			onCleanup(() => {
+				element.removeEventListener('pointerdown', pointerDown);
+				if (state.activeDraggable === element) {
+					events.resetDragState();
+				}
+				draggables.delete(element);
+			});
+		}
+	};
+}
+
+export function cleanupDraggableElement(
+	element: HTMLElement,
+	pointerDown: (event: PointerEvent) => void,
+	activeClassName: string,
+) {
+	element.removeEventListener('pointerdown', pointerDown);
+	element.classList.remove(activeClassName);
+	element.removeAttribute('aria-grabbed');
+	element.removeAttribute('aria-roledescription');
+	element.style.touchAction = '';
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.dropzone.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.dropzone.ts
@@ -1,0 +1,90 @@
+import { getDropzoneCoordinates } from './createDnD.logic';
+import { getOwner, onCleanup } from 'solid-js';
+import { DndPayload } from './models';
+import { DnDContext, DndDropzoneDirective } from './createDnD.context';
+import { EventController } from './createDnD.events';
+
+export function createDropzoneDirective<Payload extends DndPayload>(
+	context: DnDContext<Payload>,
+	events: EventController<Payload>,
+): DndDropzoneDirective<Payload> {
+	const { state, dropzones, classes } = context;
+
+	return (element, accessor) => {
+		element.setAttribute('aria-roledescription', 'drop zone');
+
+		const leaveCurrentZone = () => {
+			if (!state.activeDrag || state.hoveredDropzone !== element) return;
+
+			accessor().onDragLeave?.(state.activeDrag);
+			events.removePlacementClasses(element);
+			element.classList.remove(classes.overClassName);
+			state.hoveredDropzone = null;
+			state.hoveredPlacement = undefined;
+		};
+
+		const pointerEnter = (event: PointerEvent) => {
+			if (!state.activeDrag) return;
+
+			const binding = accessor();
+			if (!binding || binding.disabled || !binding.id) return;
+
+			if (state.hoveredDropzone && state.hoveredDropzone !== element) {
+				const previousBinding = dropzones.get(state.hoveredDropzone)?.getBinding();
+				previousBinding?.onDragLeave?.(state.activeDrag);
+				events.removePlacementClasses(state.hoveredDropzone);
+				state.hoveredDropzone.classList.remove(classes.overClassName);
+			}
+
+			const enteringNewZone = state.hoveredDropzone !== element;
+			state.hoveredDropzone = element;
+			element.classList.add(classes.overClassName);
+			events.updatePlacementClasses(element, binding, event.clientY);
+
+			state.activeDrag = {
+				...state.activeDrag,
+				position: getDropzoneCoordinates(
+					element,
+					binding,
+					event.clientX,
+					event.clientY,
+				),
+			};
+
+			if (enteringNewZone) {
+				binding.onDragEnter?.(state.activeDrag);
+			}
+		};
+
+		const pointerLeave = () => leaveCurrentZone();
+		element.addEventListener('pointerenter', pointerEnter);
+		element.addEventListener('pointerleave', pointerLeave);
+
+		dropzones.set(element, { element, getBinding: accessor, pointerEnter, pointerLeave });
+
+		if (getOwner()) {
+			onCleanup(() => {
+				element.removeEventListener('pointerenter', pointerEnter);
+				element.removeEventListener('pointerleave', pointerLeave);
+				if (state.hoveredDropzone === element) {
+					events.clearHoveredDropzone();
+				}
+				dropzones.delete(element);
+			});
+		}
+	};
+}
+
+export function cleanupDropzoneElement(
+	element: HTMLElement,
+	pointerEnter: (event: PointerEvent) => void,
+	pointerLeave: () => void,
+	removePlacementClasses: (element: HTMLElement) => void,
+	overClassName: string,
+) {
+	element.removeEventListener('pointerenter', pointerEnter);
+	element.removeEventListener('pointerleave', pointerLeave);
+	removePlacementClasses(element);
+	element.classList.remove(overClassName);
+	element.removeAttribute('aria-roledescription');
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.events.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.events.ts
@@ -1,0 +1,292 @@
+import { buildDropState, getDropzoneCoordinates, getSortableSource } from './createDnD.logic';
+import { DndPayload, DragState, DropzoneBinding } from './models';
+import { DnDContext, PendingDrag } from './createDnD.context';
+import { createHoverHelpers } from './createDnD.hover';
+
+export type EventController<Payload extends DndPayload> = {
+	removePlacementClasses: (element: HTMLElement) => void;
+	updatePlacementClasses: (
+		element: HTMLElement,
+		binding: DropzoneBinding<Payload>,
+		clientY?: number,
+	) => void;
+	clearHoveredDropzone: () => void;
+	addGlobalListeners: () => void;
+	removeGlobalListeners: () => void;
+	activateDrag: (pending: PendingDrag<Payload>, event: PointerEvent) => void;
+	resetDragState: (dragState?: DragState<Payload> | null) => void;
+	cancelPendingDrag: () => void;
+	cancelActiveDrag: () => void;
+	onPointerMove: (event: PointerEvent) => void;
+	onPointerUp: (event: PointerEvent) => void;
+	onPointerCancel: () => void;
+	onKeyDown: (event: KeyboardEvent) => void;
+};
+
+export function createEventController<Payload extends DndPayload>(
+	context: DnDContext<Payload>,
+): EventController<Payload> {
+	const { state, config, classes, preview, draggables, dropzones, dragThreshold } = context;
+	const { removePlacementClasses, updatePlacementClasses, clearHoveredDropzone } =
+		createHoverHelpers(context);
+
+	const getDropzoneFromPoint = (clientX: number, clientY: number) => {
+		if (typeof document.elementFromPoint === 'function') {
+			let current: Element | null = document.elementFromPoint(clientX, clientY);
+			while (current) {
+				if (current instanceof HTMLElement && dropzones.has(current)) {
+					return current;
+				}
+				current = current.parentElement;
+			}
+		}
+
+		for (const [element] of dropzones) {
+			const bounds = element.getBoundingClientRect();
+			if (
+				clientX >= bounds.left &&
+				clientX <= bounds.right &&
+				clientY >= bounds.top &&
+				clientY <= bounds.bottom
+			) {
+				return element;
+			}
+		}
+
+		return null;
+	};
+
+	const applyHoveredDropzoneFromPoint = (event: PointerEvent) => {
+		if (!state.activeDrag) return;
+
+		const nextZone = getDropzoneFromPoint(event.clientX, event.clientY);
+		const previousZone = state.hoveredDropzone;
+
+		if (previousZone && previousZone !== nextZone) {
+			const previousBinding = dropzones.get(previousZone)?.getBinding();
+			previousBinding?.onDragLeave?.(state.activeDrag);
+			removePlacementClasses(previousZone);
+			previousZone.classList.remove(classes.overClassName);
+			state.hoveredDropzone = null;
+			state.hoveredPlacement = undefined;
+		}
+
+		if (!nextZone) {
+			if (state.activeDrag.position) {
+				state.activeDrag = {
+					...state.activeDrag,
+					position: undefined,
+				};
+			}
+			return;
+		}
+
+		const binding = dropzones.get(nextZone)?.getBinding();
+		if (!binding || binding.disabled || !binding.id) {
+			if (state.activeDrag.position) {
+				state.activeDrag = {
+					...state.activeDrag,
+					position: undefined,
+				};
+			}
+			return;
+		}
+
+		const enteringNewZone = state.hoveredDropzone !== nextZone;
+		state.hoveredDropzone = nextZone;
+		nextZone.classList.add(classes.overClassName);
+		updatePlacementClasses(nextZone, binding, event.clientY);
+
+		state.activeDrag = {
+			...state.activeDrag,
+			position: getDropzoneCoordinates(nextZone, binding, event.clientX, event.clientY),
+		};
+
+		if (enteringNewZone) {
+			binding.onDragEnter?.(state.activeDrag);
+		}
+	};
+
+	const addGlobalListeners = () => {
+		if (state.globalListenersActive) return;
+		state.globalListenersActive = true;
+		document.addEventListener('pointermove', onPointerMove);
+		document.addEventListener('pointerup', onPointerUp);
+		document.addEventListener('pointercancel', onPointerCancel);
+		document.addEventListener('keydown', onKeyDown);
+	};
+
+	const removeGlobalListeners = () => {
+		if (!state.globalListenersActive) return;
+		state.globalListenersActive = false;
+		document.removeEventListener('pointermove', onPointerMove);
+		document.removeEventListener('pointerup', onPointerUp);
+		document.removeEventListener('pointercancel', onPointerCancel);
+		document.removeEventListener('keydown', onKeyDown);
+	};
+
+	const resetDragState = (dragState: DragState<Payload> | null = state.activeDrag) => {
+		if (state.activeDraggable && dragState) {
+			draggables.get(state.activeDraggable)?.getBinding().onDragEnd?.(dragState);
+		}
+
+		if (state.activeDraggable) {
+			state.activeDraggable.classList.remove(classes.activeClassName);
+			state.activeDraggable.setAttribute('aria-grabbed', 'false');
+		}
+
+		clearHoveredDropzone();
+		preview.remove();
+		state.activeDrag = null;
+		state.activeDraggable = null;
+		state.pendingDrag = null;
+		removeGlobalListeners();
+	};
+
+	const activateDrag = (pending: PendingDrag<Payload>, event: PointerEvent) => {
+		const sourceBounds = pending.element.getBoundingClientRect();
+
+		state.activeDrag = {
+			sourceId: pending.binding.id,
+			payload: pending.payload,
+			pointerOffset: {
+				x: pending.startX - sourceBounds.left,
+				y: pending.startY - sourceBounds.top,
+			},
+			sortable: getSortableSource(pending.binding),
+		};
+
+		state.activeDraggable = pending.element;
+		pending.element.classList.add(classes.activeClassName);
+		pending.element.setAttribute('aria-grabbed', 'true');
+
+		preview.mount({
+			sourceElement: pending.element,
+			binding: pending.binding,
+			state: state.activeDrag,
+			event,
+		});
+
+		pending.binding.onDragStart?.(state.activeDrag);
+		state.pendingDrag = null;
+	};
+
+	const cancelPendingDrag = () => {
+		state.pendingDrag = null;
+		removeGlobalListeners();
+	};
+
+	const cancelActiveDrag = () => {
+		if (state.activeDrag) {
+			config.onDragCancel?.(state.activeDrag);
+		}
+		resetDragState();
+	};
+
+	const onPointerMove = (event: PointerEvent) => {
+		if (state.pendingDrag && !state.activeDrag) {
+			const dx = event.clientX - state.pendingDrag.startX;
+			const dy = event.clientY - state.pendingDrag.startY;
+			if (dx * dx + dy * dy >= dragThreshold * dragThreshold) {
+				activateDrag(state.pendingDrag, event);
+			} else {
+				return;
+			}
+		}
+
+		if (!state.activeDrag) return;
+		preview.updatePosition(event.clientX, event.clientY);
+		applyHoveredDropzoneFromPoint(event);
+	};
+
+	const onPointerUp = (event: PointerEvent) => {
+		if (state.pendingDrag && !state.activeDrag) {
+			cancelPendingDrag();
+			return;
+		}
+
+		if (state.activeDrag) {
+			applyHoveredDropzoneFromPoint(event);
+		}
+
+		const dragState = state.activeDrag;
+		const zoneElement = state.hoveredDropzone;
+		if (!dragState || !zoneElement) {
+			if (dragState) {
+				config.onInvalidDrop?.({
+					sourceId: dragState.sourceId,
+					payload: dragState.payload,
+					sortable: dragState.sortable,
+				});
+			}
+			resetDragState(dragState);
+			return;
+		}
+
+		const zoneBinding = dropzones.get(zoneElement)?.getBinding();
+		if (!zoneBinding || !zoneBinding.id || zoneBinding.disabled) {
+			config.onInvalidDrop?.({
+				sourceId: dragState.sourceId,
+				payload: dragState.payload,
+				sortable: dragState.sortable,
+			});
+			resetDragState(dragState);
+			return;
+		}
+
+		const dropState = buildDropState(
+			dragState,
+			zoneBinding,
+			state.hoveredPlacement,
+			getDropzoneCoordinates(zoneElement, zoneBinding, event.clientX, event.clientY),
+		);
+
+		if (zoneBinding.accepts && !zoneBinding.accepts(dropState)) {
+			config.onInvalidDrop?.({
+				sourceId: dropState.sourceId,
+				payload: dropState.payload,
+				sortable: dropState.sortable,
+			});
+			resetDragState(dropState);
+			return;
+		}
+
+		state.activeDrag = dropState;
+		zoneBinding.onDrop?.(dropState);
+		config.onDrop?.(zoneBinding.id, dropState);
+		resetDragState(dropState);
+	};
+
+	const onPointerCancel = () => {
+		if (state.pendingDrag && !state.activeDrag) {
+			cancelPendingDrag();
+			return;
+		}
+		cancelActiveDrag();
+	};
+
+	const onKeyDown = (event: KeyboardEvent) => {
+		if (event.key !== 'Escape') return;
+		if (state.pendingDrag && !state.activeDrag) {
+			cancelPendingDrag();
+			return;
+		}
+		if (state.activeDrag) cancelActiveDrag();
+	};
+
+	return {
+		removePlacementClasses,
+		updatePlacementClasses,
+		clearHoveredDropzone,
+		addGlobalListeners,
+		removeGlobalListeners,
+		activateDrag,
+		resetDragState,
+		cancelPendingDrag,
+		cancelActiveDrag,
+		onPointerMove,
+		onPointerUp,
+		onPointerCancel,
+		onKeyDown,
+	};
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.hover.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.hover.ts
@@ -1,0 +1,55 @@
+import { resolvePlacement } from './createDnD.logic';
+import { DndPayload, DropzoneBinding } from './models';
+import { DnDContext } from './createDnD.context';
+
+export function createHoverHelpers<Payload extends DndPayload>(
+	context: DnDContext<Payload>,
+) {
+	const { state, classes } = context;
+
+	const removePlacementClasses = (element: HTMLElement) => {
+		element.classList.remove(classes.insertBeforeClassName);
+		element.classList.remove(classes.insertAfterClassName);
+	};
+
+	const updatePlacementClasses = (
+		element: HTMLElement,
+		binding: DropzoneBinding<Payload>,
+		clientY?: number,
+	) => {
+		const previousPlacement = state.hoveredPlacement;
+		removePlacementClasses(element);
+		state.hoveredPlacement = undefined;
+		if (clientY === undefined) return;
+
+		const placement = resolvePlacement(element, binding, clientY, previousPlacement);
+		if (!placement) return;
+
+		state.hoveredPlacement = placement;
+		element.classList.add(
+			placement === 'before'
+				? classes.insertBeforeClassName
+				: classes.insertAfterClassName,
+		);
+	};
+
+	const clearHoveredDropzone = () => {
+		if (state.hoveredDropzone) {
+			removePlacementClasses(state.hoveredDropzone);
+			state.hoveredDropzone.classList.remove(classes.overClassName);
+			state.hoveredDropzone = null;
+		}
+
+		if (state.activeDrag?.position) {
+			state.activeDrag = { ...state.activeDrag, position: undefined };
+		}
+
+		state.hoveredPlacement = undefined;
+	};
+
+	return {
+		removePlacementClasses,
+		updatePlacementClasses,
+		clearHoveredDropzone,
+	};
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.logic.test.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.logic.test.ts
@@ -1,0 +1,363 @@
+import {
+	getSortableSource,
+	resolvePlacement,
+	buildDropState,
+	getDropzoneCoordinates,
+} from './createDnD.logic';
+import { DraggableBinding, DropzoneBinding, DragState } from './models';
+
+// ── Test helpers ────────────────────────────────────────────────────
+
+interface TestPayload {
+	id: string;
+}
+
+function draggableBinding(
+	overrides: Partial<DraggableBinding<TestPayload>> = {},
+): DraggableBinding<TestPayload> {
+	return { id: 'item', getPayload: () => ({ id: '1' }), ...overrides };
+}
+
+function dropzoneBinding(
+	overrides: Partial<DropzoneBinding<TestPayload>> = {},
+): DropzoneBinding<TestPayload> {
+	return { id: 'zone', ...overrides };
+}
+
+function mockElement(height: number, top = 0): HTMLElement {
+	const el = document.createElement('div');
+
+	vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+		x: 0,
+		y: top,
+		width: 100,
+		height,
+		top,
+		left: 0,
+		right: 100,
+		bottom: top + height,
+		toJSON: () => ({}),
+	} as DOMRect);
+
+	return el;
+}
+
+// ── getSortableSource ───────────────────────────────────────────────
+
+describe('getSortableSource', () => {
+	it('returns undefined when no sortable binding', () => {
+		expect(getSortableSource(draggableBinding())).toBeUndefined();
+	});
+
+	it('returns undefined when listId is empty', () => {
+		const binding = draggableBinding({ sortable: { listId: '', index: 0 } });
+		expect(getSortableSource(binding)).toBeUndefined();
+	});
+
+	it('returns undefined when index is NaN', () => {
+		const binding = draggableBinding({ sortable: { listId: 'list', index: NaN } });
+		expect(getSortableSource(binding)).toBeUndefined();
+	});
+
+	it('returns undefined when index is Infinity', () => {
+		const binding = draggableBinding({
+			sortable: { listId: 'list', index: Infinity },
+		});
+		expect(getSortableSource(binding)).toBeUndefined();
+	});
+
+	it('returns undefined when index is -Infinity', () => {
+		const binding = draggableBinding({
+			sortable: { listId: 'list', index: -Infinity },
+		});
+		expect(getSortableSource(binding)).toBeUndefined();
+	});
+
+	it('returns source meta for a valid binding', () => {
+		const binding = draggableBinding({
+			sortable: { listId: 'list-a', index: 2 },
+		});
+
+		expect(getSortableSource(binding)).toEqual({
+			sourceListId: 'list-a',
+			sourceIndex: 2,
+		});
+	});
+
+	it('returns source meta for index zero', () => {
+		const binding = draggableBinding({
+			sortable: { listId: 'list-a', index: 0 },
+		});
+
+		expect(getSortableSource(binding)).toEqual({
+			sourceListId: 'list-a',
+			sourceIndex: 0,
+		});
+	});
+});
+
+// ── resolvePlacement ────────────────────────────────────────────────
+
+describe('resolvePlacement', () => {
+	it('returns undefined when no sortable binding', () => {
+		const el = mockElement(100);
+		expect(resolvePlacement(el, dropzoneBinding(), 50)).toBeUndefined();
+	});
+
+	it('returns undefined when element height is zero', () => {
+		const el = mockElement(0);
+		const binding = dropzoneBinding({ sortable: { listId: 'l', index: 0 } });
+
+		expect(resolvePlacement(el, binding, 0)).toBeUndefined();
+	});
+
+	it('returns undefined when element height is negative', () => {
+		const el = mockElement(-10);
+		const binding = dropzoneBinding({ sortable: { listId: 'l', index: 0 } });
+
+		expect(resolvePlacement(el, binding, 0)).toBeUndefined();
+	});
+
+	it.each([
+		['at top (0%)', 0],
+		['in upper region (20%)', 20],
+		['at exact threshold (40%)', 40],
+	])('returns "before" when pointer is %s', (_label, clientY) => {
+		const el = mockElement(100);
+		const binding = dropzoneBinding({ sortable: { listId: 'l', index: 0 } });
+
+		expect(resolvePlacement(el, binding, clientY)).toBe('before');
+	});
+
+	it.each([
+		['at exact threshold (60%)', 60],
+		['in lower region (80%)', 80],
+		['at bottom (100%)', 100],
+	])('returns "after" when pointer is %s', (_label, clientY) => {
+		const el = mockElement(100);
+		const binding = dropzoneBinding({ sortable: { listId: 'l', index: 0 } });
+
+		expect(resolvePlacement(el, binding, clientY)).toBe('after');
+	});
+
+	it('preserves "before" in hysteresis zone (40-60%)', () => {
+		const el = mockElement(100);
+		const binding = dropzoneBinding({ sortable: { listId: 'l', index: 0 } });
+
+		expect(resolvePlacement(el, binding, 50, 'before')).toBe('before');
+	});
+
+	it('preserves "after" in hysteresis zone (40-60%)', () => {
+		const el = mockElement(100);
+		const binding = dropzoneBinding({ sortable: { listId: 'l', index: 0 } });
+
+		expect(resolvePlacement(el, binding, 50, 'after')).toBe('after');
+	});
+
+	it('returns undefined in hysteresis zone with no current placement', () => {
+		const el = mockElement(100);
+		const binding = dropzoneBinding({ sortable: { listId: 'l', index: 0 } });
+
+		expect(resolvePlacement(el, binding, 50)).toBeUndefined();
+	});
+
+	it('works with non-zero top offset', () => {
+		const el = mockElement(100, 200);
+		const binding = dropzoneBinding({ sortable: { listId: 'l', index: 0 } });
+
+		// clientY = 220, relativeY = 20 → upper 40% → 'before'
+		expect(resolvePlacement(el, binding, 220)).toBe('before');
+		// clientY = 280, relativeY = 80 → lower 40% → 'after'
+		expect(resolvePlacement(el, binding, 280)).toBe('after');
+	});
+});
+
+// ── buildDropState ──────────────────────────────────────────────────
+
+describe('buildDropState', () => {
+	const baseState: DragState<TestPayload> = {
+		sourceId: 'item-1',
+		payload: { id: '1' },
+		sortable: { sourceListId: 'list-a', sourceIndex: 0 },
+	};
+
+	it('returns same reference when drag state has no sortable', () => {
+		const state: DragState<TestPayload> = {
+			sourceId: 'x',
+			payload: { id: '1' },
+		};
+		const result = buildDropState(
+			state,
+			dropzoneBinding({ sortable: { listId: 'l', index: 0 } }),
+		);
+
+		expect(result).toBe(state);
+	});
+
+	it('returns same reference when zone has no sortable', () => {
+		const result = buildDropState(baseState, dropzoneBinding());
+		expect(result).toBe(baseState);
+	});
+
+	it('returns same reference when zone sortable has empty listId', () => {
+		const result = buildDropState(
+			baseState,
+			dropzoneBinding({ sortable: { listId: '', index: 0 } }),
+		);
+
+		expect(result).toBe(baseState);
+	});
+
+	it('uses zone index as targetIndex for "before" placement', () => {
+		const result = buildDropState(
+			baseState,
+			dropzoneBinding({ sortable: { listId: 'list-b', index: 2 } }),
+			'before',
+		);
+
+		expect(result.sortable?.targetListId).toBe('list-b');
+		expect(result.sortable?.targetIndex).toBe(2);
+		expect(result.sortable?.placement).toBe('before');
+	});
+
+	it('increments zone index for "after" placement', () => {
+		const result = buildDropState(
+			baseState,
+			dropzoneBinding({ sortable: { listId: 'list-b', index: 2 } }),
+			'after',
+		);
+
+		expect(result.sortable?.targetIndex).toBe(3);
+		expect(result.sortable?.placement).toBe('after');
+	});
+
+	it('does not set placement when none provided', () => {
+		const result = buildDropState(
+			baseState,
+			dropzoneBinding({ sortable: { listId: 'list-b', index: 2 } }),
+		);
+
+		expect(result.sortable?.placement).toBeUndefined();
+		expect(result.sortable?.targetIndex).toBe(2);
+	});
+
+	it('adjusts targetIndex for same-list reorder when source < target', () => {
+		const state: DragState<TestPayload> = {
+			sourceId: 'item-1',
+			payload: { id: '1' },
+			sortable: { sourceListId: 'list-a', sourceIndex: 0 },
+		};
+
+		// zone index 2, "after" → base 3, same-list adjustment → 2
+		const result = buildDropState(
+			state,
+			dropzoneBinding({ sortable: { listId: 'list-a', index: 2 } }),
+			'after',
+		);
+
+		expect(result.sortable?.targetIndex).toBe(2);
+	});
+
+	it('does not adjust targetIndex for cross-list', () => {
+		const result = buildDropState(
+			baseState,
+			dropzoneBinding({ sortable: { listId: 'list-b', index: 2 } }),
+			'after',
+		);
+
+		expect(result.sortable?.targetIndex).toBe(3);
+	});
+
+	it('does not adjust when source >= target in same list', () => {
+		const state: DragState<TestPayload> = {
+			sourceId: 'item-3',
+			payload: { id: '3' },
+			sortable: { sourceListId: 'list-a', sourceIndex: 3 },
+		};
+
+		const result = buildDropState(
+			state,
+			dropzoneBinding({ sortable: { listId: 'list-a', index: 1 } }),
+			'before',
+		);
+
+		expect(result.sortable?.targetIndex).toBe(1);
+	});
+
+	it('defaults to index 0 when zone index is NaN', () => {
+		const result = buildDropState(
+			baseState,
+			dropzoneBinding({ sortable: { listId: 'list-b', index: NaN } }),
+		);
+
+		expect(result.sortable?.targetIndex).toBe(0);
+	});
+
+	it('handles same-index same-list (no-op reorder)', () => {
+		const state: DragState<TestPayload> = {
+			sourceId: 'item-1',
+			payload: { id: '1' },
+			sortable: { sourceListId: 'list-a', sourceIndex: 1 },
+		};
+
+		const result = buildDropState(
+			state,
+			dropzoneBinding({ sortable: { listId: 'list-a', index: 1 } }),
+			'before',
+		);
+
+		// index 1, "before" → 1, source (1) is NOT < target (1) → no adjustment
+		expect(result.sortable?.targetIndex).toBe(1);
+	});
+
+	it('attaches dropPosition when provided', () => {
+		const result = buildDropState(
+			baseState,
+			dropzoneBinding({ sortable: { listId: 'list-b', index: 2 } }),
+			'before',
+			{ zoneId: 'zone', x: 24, y: 40 },
+		);
+
+		expect(result.dropPosition).toEqual({ zoneId: 'zone', x: 24, y: 40 });
+	});
+});
+
+// ── getDropzoneCoordinates ─────────────────────────────────────────
+
+describe('getDropzoneCoordinates', () => {
+	it('returns undefined when zone binding has empty id', () => {
+		const element = mockElement(100);
+		const result = getDropzoneCoordinates(
+			element,
+			dropzoneBinding({ id: '' }),
+			50,
+			60,
+		);
+
+		expect(result).toBeUndefined();
+	});
+
+	it('returns coordinates relative to zone top-left', () => {
+		const element = mockElement(120, 200);
+		vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+			x: 40,
+			y: 200,
+			width: 200,
+			height: 120,
+			top: 200,
+			left: 40,
+			right: 240,
+			bottom: 320,
+			toJSON: () => ({}),
+		} as DOMRect);
+
+		const result = getDropzoneCoordinates(
+			element,
+			dropzoneBinding({ id: 'zone-a' }),
+			70,
+			260,
+		);
+
+		expect(result).toEqual({ zoneId: 'zone-a', x: 30, y: 60 });
+	});
+});

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.logic.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.logic.ts
@@ -1,0 +1,156 @@
+import {
+	DndPayload,
+	DropzoneCoordinates,
+	DragState,
+	DraggableBinding,
+	DropzoneBinding,
+	SortablePlacement,
+} from './models';
+
+/**
+ * Converts viewport pointer coordinates into coordinates relative to a dropzone.
+ */
+export function getDropzoneCoordinates<Payload extends DndPayload>(
+	element: HTMLElement,
+	binding: DropzoneBinding<Payload>,
+	clientX: number,
+	clientY: number,
+): DropzoneCoordinates | undefined {
+	if (!binding.id) {
+		return undefined;
+	}
+
+	const bounds = element.getBoundingClientRect();
+
+	return {
+		zoneId: binding.id,
+		x: clientX - bounds.left,
+		y: clientY - bounds.top,
+	};
+}
+
+/**
+ * Extracts sortable source metadata from a draggable binding.
+ *
+ * Returns `undefined` when the binding has no sortable config,
+ * an empty `listId`, or a non-finite index.
+ */
+export function getSortableSource<Payload extends DndPayload>(
+	binding: DraggableBinding<Payload>,
+) {
+	const sortableBinding = binding.sortable;
+
+	if (!sortableBinding || !sortableBinding.listId) {
+		return undefined;
+	}
+
+	if (!Number.isFinite(sortableBinding.index)) {
+		return undefined;
+	}
+
+	return {
+		sourceListId: sortableBinding.listId,
+		sourceIndex: sortableBinding.index,
+	};
+}
+
+/**
+ * Determines whether the pointer is in the "before" or "after" region
+ * of a sortable dropzone element.
+ *
+ * The element is divided into three zones:
+ * - Top 40 %  → `'before'`
+ * - Bottom 40 % → `'after'`
+ * - Middle 20 % (hysteresis) → keeps `currentPlacement` to prevent flickering
+ *
+ * Returns `undefined` when the binding has no sortable config,
+ * the element has zero height, or no placement can be resolved.
+ */
+export function resolvePlacement<Payload extends DndPayload>(
+	element: HTMLElement,
+	binding: DropzoneBinding<Payload>,
+	clientY: number,
+	currentPlacement?: SortablePlacement,
+): SortablePlacement | undefined {
+	if (!binding.sortable) {
+		return undefined;
+	}
+
+	const bounds = element.getBoundingClientRect();
+
+	if (bounds.height <= 0) {
+		return undefined;
+	}
+
+	const relativeY = clientY - bounds.top;
+	const beforeThreshold = bounds.height * 0.4;
+	const afterThreshold = bounds.height * 0.6;
+
+	if (relativeY <= beforeThreshold) {
+		return 'before';
+	}
+
+	if (relativeY >= afterThreshold) {
+		return 'after';
+	}
+
+	return currentPlacement;
+}
+
+/**
+ * Builds the final {@link DragState} for a drop, enriching it with
+ * sortable target metadata (target list, target index, placement).
+ *
+ * For same-list reorders where the source index is before the computed
+ * target index, `targetIndex` is decremented by one to account for the
+ * source item being removed first.
+ *
+ * Returns the original `state` unchanged when either side lacks sortable
+ * metadata or the zone's `listId` is empty.
+ */
+export function buildDropState<Payload extends DndPayload>(
+	state: DragState<Payload>,
+	zoneBinding: DropzoneBinding<Payload>,
+	placement?: SortablePlacement,
+	dropPosition?: DropzoneCoordinates,
+): DragState<Payload> {
+	if (!state.sortable || !zoneBinding.sortable || !zoneBinding.sortable.listId) {
+		if (!dropPosition) {
+			return state;
+		}
+
+		return {
+			...state,
+			dropPosition,
+		};
+	}
+
+	const baseTargetIndex = Number.isFinite(zoneBinding.sortable.index)
+		? zoneBinding.sortable.index
+		: 0;
+
+	let targetIndex = placement === 'after' ? baseTargetIndex + 1 : baseTargetIndex;
+
+	if (
+		state.sortable.sourceListId === zoneBinding.sortable.listId &&
+		state.sortable.sourceIndex < targetIndex
+	) {
+		targetIndex -= 1;
+	}
+
+	const nextSortable = {
+		...state.sortable,
+		targetListId: zoneBinding.sortable.listId,
+		targetIndex,
+	};
+
+	if (placement) {
+		nextSortable.placement = placement;
+	}
+
+	return {
+		...state,
+		sortable: nextSortable,
+		dropPosition,
+	};
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.preview.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.preview.ts
@@ -1,0 +1,110 @@
+import { DndPayload, DragState, DraggableBinding } from './models';
+
+type PreviewOffset = { x: number; y: number };
+
+type MountContext<Payload extends DndPayload> = {
+	sourceElement: HTMLElement;
+	binding: DraggableBinding<Payload>;
+	state: DragState<Payload>;
+	event: PointerEvent;
+};
+
+/**
+ * Creates a manager for the floating drag preview element.
+ *
+ * @param previewClassName - CSS class added to the preview element.
+ * @param zIndex - CSS `z-index` for the preview (default `1000`).
+ */
+export function createPreviewManager(
+	previewClassName: string,
+	zIndex: string | number = 1000,
+) {
+	let activePreview: HTMLElement | null = null;
+	let previewOffset: PreviewOffset | null = null;
+
+	/** Creates a shallow clone of the source element styled as a drag ghost. */
+	const createDefaultPreview = (element: HTMLElement) => {
+		const preview = element.cloneNode(true) as HTMLElement;
+		const sourceRect = element.getBoundingClientRect();
+
+		preview.style.opacity = '0.7';
+		preview.style.boxSizing = 'border-box';
+
+		if (sourceRect.width > 0) {
+			preview.style.width = `${sourceRect.width}px`;
+		}
+
+		if (sourceRect.height > 0) {
+			preview.style.height = `${sourceRect.height}px`;
+		}
+
+		return preview;
+	};
+
+	/** Removes the active preview from the DOM and resets internal state. */
+	const remove = () => {
+		if (activePreview?.parentNode) {
+			activePreview.parentNode.removeChild(activePreview);
+		}
+
+		activePreview = null;
+		previewOffset = null;
+	};
+
+	/** Repositions the preview element to follow the pointer. */
+	const updatePosition = (clientX: number, clientY: number) => {
+		if (!activePreview || !previewOffset) {
+			return;
+		}
+
+		activePreview.style.left = `${clientX - previewOffset.x}px`;
+		activePreview.style.top = `${clientY - previewOffset.y}px`;
+	};
+
+	/**
+	 * Creates (or replaces) the drag preview and appends it to `document.body`.
+	 * Uses the binding's `createDragPreview` when provided, falling back to a
+	 * cloned ghost of the source element.
+	 */
+	const mount = <Payload extends DndPayload>(context: MountContext<Payload>) => {
+		remove();
+
+		const { sourceElement, binding, state, event } = context;
+
+		let preview =
+			binding.createDragPreview?.({
+				state,
+				sourceElement,
+			}) ?? createDefaultPreview(sourceElement);
+
+		if (!(preview instanceof HTMLElement)) {
+			preview = createDefaultPreview(sourceElement);
+		}
+
+		if (preview.isConnected) {
+			preview = preview.cloneNode(true) as HTMLElement;
+		}
+
+		const sourceRect = sourceElement.getBoundingClientRect();
+		previewOffset = {
+			x: event.clientX - sourceRect.left,
+			y: event.clientY - sourceRect.top,
+		};
+
+		preview.classList.add(previewClassName);
+		preview.style.position = 'fixed';
+		preview.style.pointerEvents = 'none';
+		preview.style.margin = '0';
+		preview.style.zIndex = String(zIndex);
+
+		activePreview = preview;
+		document.body.appendChild(preview);
+		updatePosition(event.clientX, event.clientY);
+	};
+
+	return {
+		mount,
+		remove,
+		updatePosition,
+	};
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.test.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.test.ts
@@ -1,0 +1,1258 @@
+import { createRoot } from 'solid-js';
+import { createDnD } from './createDnD';
+import { DnDConfig, DndPayload, DnDInstance } from './models';
+
+// ── Payload type used across all tests ──────────────────────────────
+
+interface CardPayload {
+  cardId: string;
+}
+
+// ── Test helpers (issue #15) ────────────────────────────────────────
+
+const instances: DnDInstance<any>[] = [];
+
+/**
+ * Creates a DnD instance with `dragThreshold: 0` by default so that
+ * existing pointer-based tests activate the drag immediately on pointerdown.
+ */
+function createTestDnD<P extends DndPayload>(config: DnDConfig<P> = {}) {
+  const dnd = createDnD<P>({ dragThreshold: 0, ...config });
+  instances.push(dnd);
+  return dnd;
+}
+
+/** Shortcut: creates a `<div>`, appends it to `document.body`, and returns it. */
+function createEl(tag = 'div'): HTMLElement {
+  const el = document.createElement(tag);
+  document.body.appendChild(el);
+  return el;
+}
+
+// ── Suite ───────────────────────────────────────────────────────────
+
+describe('createDnD', () => {
+  afterEach(() => {
+    instances.forEach((dnd) => dnd.destroy());
+    instances.length = 0;
+    document.body.innerHTML = '';
+  });
+
+  // ── Basic drag & drop ───────────────────────────────────────────
+
+  it('drops payload on accepted zone', () => {
+    const draggable = createEl();
+    const zone = createEl();
+
+    const dragStart = vi.fn();
+    const dragEnd = vi.fn();
+    const dropHandler = vi.fn();
+    const onDrop = vi.fn();
+
+    const dnd = createTestDnD<CardPayload>({
+      activeClassName: 'is-active',
+      overClassName: 'is-over',
+      onDrop,
+    });
+
+    vi.spyOn(zone, 'getBoundingClientRect').mockReturnValue({
+      x: 100,
+      y: 200,
+      width: 160,
+      height: 120,
+      top: 200,
+      left: 100,
+      right: 260,
+      bottom: 320,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'zone-1',
+      getPayload: () => ({ cardId: 'alpha' }),
+      onDragStart: dragStart,
+      onDragEnd: dragEnd,
+    }));
+
+    dnd.dndDropzone(zone, () => ({
+      id: 'zone-2',
+      accepts: () => true,
+      onDrop: dropHandler,
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientX: 110, clientY: 210 }));
+    zone.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true, clientX: 145, clientY: 245 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 160, clientY: 255 }));
+
+    expect(dragStart).toHaveBeenCalledTimes(1);
+    expect(dropHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: 'zone-1',
+        payload: { cardId: 'alpha' },
+        position: { zoneId: 'zone-2', x: 60, y: 55 },
+        dropPosition: { zoneId: 'zone-2', x: 60, y: 55 },
+      }),
+    );
+    expect(onDrop).toHaveBeenCalledWith(
+      'zone-2',
+      expect.objectContaining({
+        sourceId: 'zone-1',
+        payload: { cardId: 'alpha' },
+        dropPosition: { zoneId: 'zone-2', x: 60, y: 55 },
+      }),
+    );
+    expect(dragEnd).toHaveBeenCalledTimes(1);
+    expect(draggable.classList.contains('is-active')).toBe(false);
+    expect(zone.classList.contains('is-over')).toBe(false);
+  });
+
+  it('exposes pointer offset from source element on drop state', () => {
+    const draggable = createEl();
+    const zone = createEl();
+    const dropHandler = vi.fn();
+
+    vi.spyOn(draggable, 'getBoundingClientRect').mockReturnValue({
+      x: 80,
+      y: 120,
+      width: 140,
+      height: 48,
+      top: 120,
+      left: 80,
+      right: 220,
+      bottom: 168,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    vi.spyOn(zone, 'getBoundingClientRect').mockReturnValue({
+      x: 300,
+      y: 200,
+      width: 240,
+      height: 180,
+      top: 200,
+      left: 300,
+      right: 540,
+      bottom: 380,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'item-a',
+      getPayload: () => ({ cardId: 'offset' }),
+    }));
+
+    dnd.dndDropzone(zone, () => ({
+      id: 'drop-zone',
+      onDrop: dropHandler,
+    }));
+
+    draggable.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true, clientX: 110, clientY: 150 }),
+    );
+    zone.dispatchEvent(
+      new MouseEvent('pointerenter', { bubbles: true, clientX: 340, clientY: 260 }),
+    );
+    document.dispatchEvent(
+      new MouseEvent('pointerup', { bubbles: true, clientX: 360, clientY: 280 }),
+    );
+
+    expect(dropHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pointerOffset: {
+          x: 30,
+          y: 30,
+        },
+        dropPosition: {
+          zoneId: 'drop-zone',
+          x: 60,
+          y: 80,
+        },
+      }),
+    );
+  });
+
+  it('handles rejected drops and calls onInvalidDrop', () => {
+    const draggable = createEl();
+    const zone = createEl();
+
+    const onInvalidDrop = vi.fn();
+    const zoneDrop = vi.fn();
+
+    const dnd = createTestDnD<CardPayload>({ onInvalidDrop });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'zone-1',
+      getPayload: () => ({ cardId: 'beta' }),
+    }));
+
+    dnd.dndDropzone(zone, () => ({
+      id: 'zone-2',
+      accepts: () => false,
+      onDrop: zoneDrop,
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    zone.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+
+    expect(zoneDrop).not.toHaveBeenCalled();
+    expect(onInvalidDrop).toHaveBeenCalledWith({ sourceId: 'zone-1', payload: { cardId: 'beta' } });
+    expect(onInvalidDrop).not.toHaveBeenCalledWith(
+      expect.objectContaining({ position: expect.anything() }),
+    );
+    expect(onInvalidDrop).not.toHaveBeenCalledWith(
+      expect.objectContaining({ dropPosition: expect.anything() }),
+    );
+  });
+
+  it('tracks live dropzone-relative coordinates on active drag state', () => {
+    const draggable = createEl();
+    const zone = createEl();
+
+    vi.spyOn(zone, 'getBoundingClientRect').mockReturnValue({
+      x: 40,
+      y: 50,
+      width: 240,
+      height: 180,
+      top: 50,
+      left: 40,
+      right: 280,
+      bottom: 230,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'drag-item',
+      getPayload: () => ({ cardId: 'position' }),
+    }));
+
+    dnd.dndDropzone(zone, () => ({
+      id: 'drop-zone',
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientX: 30, clientY: 30 }));
+    zone.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true, clientX: 60, clientY: 80 }));
+
+    expect(dnd.getActiveDrag()?.position).toEqual({
+      zoneId: 'drop-zone',
+      x: 20,
+      y: 30,
+    });
+
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 90, clientY: 95 }));
+
+    expect(dnd.getActiveDrag()?.position).toEqual({
+      zoneId: 'drop-zone',
+      x: 50,
+      y: 45,
+    });
+
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+  });
+
+  it('acquires hovered dropzone from pointermove without pointerenter', () => {
+    const draggable = createEl();
+    const zone = createEl();
+    const dropHandler = vi.fn();
+
+    vi.spyOn(zone, 'getBoundingClientRect').mockReturnValue({
+      x: 200,
+      y: 100,
+      width: 150,
+      height: 120,
+      top: 100,
+      left: 200,
+      right: 350,
+      bottom: 220,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'source',
+      getPayload: () => ({ cardId: 'move-hover' }),
+    }));
+
+    dnd.dndDropzone(zone, () => ({
+      id: 'zone',
+      onDrop: dropHandler,
+    }));
+
+    draggable.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true, clientX: 20, clientY: 20 }),
+    );
+    document.dispatchEvent(
+      new MouseEvent('pointermove', { bubbles: true, clientX: 240, clientY: 140 }),
+    );
+    document.dispatchEvent(
+      new MouseEvent('pointerup', { bubbles: true, clientX: 250, clientY: 150 }),
+    );
+
+    expect(dropHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: 'source',
+        payload: { cardId: 'move-hover' },
+        dropPosition: { zoneId: 'zone', x: 50, y: 50 },
+      }),
+    );
+  });
+
+  it('ignores invalid bindings and resets state on destroy', () => {
+    const draggable = createEl();
+
+    const onInvalidDrop = vi.fn();
+
+    const dnd = createTestDnD<CardPayload>({ onInvalidDrop });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: '',
+      getPayload: () => ({ cardId: 'gamma' }),
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+
+    expect(dnd.getActiveDrag()).toBeNull();
+
+    dnd.destroy();
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+
+    expect(dnd.getActiveDrag()).toBeNull();
+    expect(onInvalidDrop).not.toHaveBeenCalled();
+  });
+
+  // ── Preview lifecycle ─────────────────────────────────────────
+
+  it('creates a default drag ghost and removes it on pointerup', () => {
+    const draggable = createEl();
+    draggable.textContent = 'Default ghost';
+
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'zone-1',
+      getPayload: () => ({ cardId: 'preview' }),
+    }));
+
+    draggable.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true, clientX: 20, clientY: 30 }),
+    );
+
+    const preview = document.querySelector('.dnd-preview') as HTMLElement | null;
+    expect(preview).not.toBeNull();
+    expect(preview?.textContent).toBe('Default ghost');
+
+    document.dispatchEvent(
+      new MouseEvent('pointermove', { bubbles: true, clientX: 65, clientY: 85 }),
+    );
+
+    expect(preview?.style.left).toBe('45px');
+    expect(preview?.style.top).toBe('55px');
+
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    expect(document.querySelector('.dnd-preview')).toBeNull();
+  });
+
+  it('uses custom preview element when provided', () => {
+    const draggable = createEl();
+
+    const createPreview = vi.fn(() => {
+      const preview = document.createElement('div');
+      preview.textContent = 'Custom preview';
+      return preview;
+    });
+
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'zone-1',
+      getPayload: () => ({ cardId: 'custom' }),
+      createDragPreview: createPreview,
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+
+    const preview = document.querySelector('.dnd-preview') as HTMLElement | null;
+    expect(createPreview).toHaveBeenCalledTimes(1);
+    expect(preview?.textContent).toBe('Custom preview');
+
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+  });
+
+  it('removes active preview on destroy', () => {
+    const draggable = createEl();
+
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'zone-1',
+      getPayload: () => ({ cardId: 'destroy' }),
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(document.querySelector('.dnd-preview')).not.toBeNull();
+
+    dnd.destroy();
+
+    expect(document.querySelector('.dnd-preview')).toBeNull();
+    expect(dnd.getActiveDrag()).toBeNull();
+  });
+
+  // ── Sortable ──────────────────────────────────────────────────
+
+  it('computes sortable target index for same-list reorder', () => {
+    const draggable = createEl();
+    const targetItem = createEl();
+
+    const dropHandler = vi.fn();
+
+    vi.spyOn(targetItem, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      width: 120,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 120,
+      bottom: 100,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'item-1',
+      getPayload: () => ({ cardId: 'same-list' }),
+      sortable: { listId: 'list-a', index: 0 },
+    }));
+
+    dnd.dndDropzone(targetItem, () => ({
+      id: 'item-2',
+      sortable: { listId: 'list-a', index: 1 },
+      onDrop: dropHandler,
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 10 }));
+    targetItem.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true, clientY: 80 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 80 }));
+
+    expect(dropHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: 'item-1',
+        payload: { cardId: 'same-list' },
+        sortable: {
+          sourceListId: 'list-a',
+          sourceIndex: 0,
+          targetListId: 'list-a',
+          targetIndex: 1,
+          placement: 'after',
+        },
+      }),
+    );
+  });
+
+  it('re-evaluates dropzone from pointerup coordinates for sortable drops', () => {
+    const draggable = createEl();
+    const zoneA = createEl();
+    const zoneB = createEl();
+
+    const onDrop = vi.fn();
+
+    let zoneARect = {
+      x: 0,
+      y: 0,
+      width: 120,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 120,
+      bottom: 100,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    let zoneBRect = {
+      x: 200,
+      y: 0,
+      width: 120,
+      height: 100,
+      top: 0,
+      left: 200,
+      right: 320,
+      bottom: 100,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    vi.spyOn(zoneA, 'getBoundingClientRect').mockImplementation(() => zoneARect);
+    vi.spyOn(zoneB, 'getBoundingClientRect').mockImplementation(() => zoneBRect);
+
+    const dnd = createTestDnD<CardPayload>({ onDrop });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'item-1',
+      getPayload: () => ({ cardId: 'release-zone' }),
+      sortable: { listId: 'list-a', index: 0 },
+    }));
+
+    dnd.dndDropzone(zoneA, () => ({
+      id: 'zone-a-item',
+      sortable: { listId: 'list-a', index: 0 },
+    }));
+
+    dnd.dndDropzone(zoneB, () => ({
+      id: 'zone-b-item',
+      sortable: { listId: 'list-b', index: 0 },
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientX: 10, clientY: 10 }));
+    zoneA.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true, clientX: 20, clientY: 20 }));
+
+    zoneARect = {
+      ...zoneARect,
+      x: -300,
+      left: -300,
+      right: -180,
+    } as DOMRect;
+    zoneBRect = {
+      ...zoneBRect,
+      x: 0,
+      left: 0,
+      right: 120,
+    } as DOMRect;
+
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 20, clientY: 20 }));
+
+    expect(onDrop).toHaveBeenCalledWith(
+      'zone-b-item',
+      expect.objectContaining({
+        sourceId: 'item-1',
+        payload: { cardId: 'release-zone' },
+        sortable: {
+          sourceListId: 'list-a',
+          sourceIndex: 0,
+          targetListId: 'list-b',
+          targetIndex: 0,
+          placement: 'before',
+        },
+      }),
+    );
+  });
+
+  it('re-evaluates sortable placement on pointerup with moved geometry', () => {
+    const draggable = createEl();
+    const targetItem = createEl();
+
+    const onDrop = vi.fn();
+
+    let targetRect = {
+      x: 0,
+      y: 0,
+      width: 120,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 120,
+      bottom: 100,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    vi.spyOn(targetItem, 'getBoundingClientRect').mockImplementation(() => targetRect);
+
+    const dnd = createTestDnD<CardPayload>({ onDrop });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'item-1',
+      getPayload: () => ({ cardId: 'release-placement' }),
+      sortable: { listId: 'list-a', index: 0 },
+    }));
+
+    dnd.dndDropzone(targetItem, () => ({
+      id: 'item-2',
+      sortable: { listId: 'list-a', index: 1 },
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientX: 10, clientY: 10 }));
+    targetItem.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true, clientX: 10, clientY: 20 }));
+
+    targetRect = {
+      ...targetRect,
+      y: -50,
+      top: -50,
+      bottom: 50,
+    } as DOMRect;
+
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 10, clientY: 20 }));
+
+    expect(onDrop).toHaveBeenCalledWith(
+      'item-2',
+      expect.objectContaining({
+        sourceId: 'item-1',
+        payload: { cardId: 'release-placement' },
+        sortable: {
+          sourceListId: 'list-a',
+          sourceIndex: 0,
+          targetListId: 'list-a',
+          targetIndex: 1,
+          placement: 'after',
+        },
+      }),
+    );
+  });
+
+  it('computes sortable target index for cross-list insertion', () => {
+    const draggable = createEl();
+    const listEndZone = createEl();
+
+    const onDrop = vi.fn();
+
+    const dnd = createTestDnD<CardPayload>({ onDrop });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'item-1',
+      getPayload: () => ({ cardId: 'cross-list' }),
+      sortable: { listId: 'list-a', index: 1 },
+    }));
+
+    dnd.dndDropzone(listEndZone, () => ({
+      id: 'list-b-end',
+      sortable: { listId: 'list-b', index: 0 },
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    listEndZone.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+
+    expect(onDrop).toHaveBeenCalledWith(
+      'list-b-end',
+      expect.objectContaining({
+        sourceId: 'item-1',
+        payload: { cardId: 'cross-list' },
+        sortable: {
+          sourceListId: 'list-a',
+          sourceIndex: 1,
+          targetListId: 'list-b',
+          targetIndex: 0,
+        },
+      }),
+    );
+  });
+
+  it('computes sortable target index for start sentinel insertion', () => {
+    const draggable = createEl();
+    const listStartZone = createEl();
+
+    const onDrop = vi.fn();
+
+    vi.spyOn(listStartZone, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      width: 120,
+      height: 40,
+      top: 0,
+      left: 0,
+      right: 120,
+      bottom: 40,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const dnd = createTestDnD<CardPayload>({ onDrop });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'item-3',
+      getPayload: () => ({ cardId: 'top-insert' }),
+      sortable: { listId: 'list-a', index: 2 },
+    }));
+
+    dnd.dndDropzone(listStartZone, () => ({
+      id: 'list-a-start',
+      sortable: { listId: 'list-a', index: 0 },
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+  listStartZone.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true, clientX: 5, clientY: 5 }));
+  document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 5, clientY: 5 }));
+
+    expect(onDrop).toHaveBeenCalledWith(
+      'list-a-start',
+      expect.objectContaining({
+        sourceId: 'item-3',
+        payload: { cardId: 'top-insert' },
+        sortable: expect.objectContaining({
+          sourceListId: 'list-a',
+          sourceIndex: 2,
+          targetListId: 'list-a',
+          targetIndex: 0,
+        }),
+      }),
+    );
+  });
+
+  it('calls onInvalidDrop when sortable zone rejects', () => {
+    const draggable = createEl();
+    const targetItem = createEl();
+
+    const onInvalidDrop = vi.fn();
+
+    const dnd = createTestDnD<CardPayload>({ onInvalidDrop });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'item-1',
+      getPayload: () => ({ cardId: 'reject' }),
+      sortable: { listId: 'list-a', index: 0 },
+    }));
+
+    dnd.dndDropzone(targetItem, () => ({
+      id: 'item-2',
+      sortable: { listId: 'list-b', index: 0 },
+      accepts: () => false,
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    targetItem.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true, clientY: 10 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+
+    expect(onInvalidDrop).toHaveBeenCalledWith({
+      sourceId: 'item-1',
+      payload: { cardId: 'reject' },
+      sortable: {
+        sourceListId: 'list-a',
+        sourceIndex: 0,
+        targetListId: 'list-b',
+        targetIndex: 0,
+      },
+    });
+  });
+
+  // ── Callback ordering ─────────────────────────────────────────
+
+  it('invokes callbacks in stable order for accepted drops', () => {
+    const draggable = createEl();
+    const zone = createEl();
+
+    const callOrder: string[] = [];
+
+    const dnd = createTestDnD<CardPayload>({
+      onDrop: () => callOrder.push('config:onDrop'),
+    });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'source-zone',
+      getPayload: () => ({ cardId: 'ordered' }),
+      onDragStart: () => callOrder.push('draggable:onDragStart'),
+      onDragEnd: () => callOrder.push('draggable:onDragEnd'),
+    }));
+
+    dnd.dndDropzone(zone, () => ({
+      id: 'target-zone',
+      onDrop: () => callOrder.push('zone:onDrop'),
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    zone.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+
+    expect(callOrder).toEqual([
+      'draggable:onDragStart',
+      'zone:onDrop',
+      'config:onDrop',
+      'draggable:onDragEnd',
+    ]);
+  });
+
+  it('fires leave for previous zone before enter for next zone', () => {
+    const draggable = createEl();
+    const zoneA = createEl();
+    const zoneB = createEl();
+
+    const events: string[] = [];
+
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'source',
+      getPayload: () => ({ cardId: 'transition' }),
+    }));
+
+    dnd.dndDropzone(zoneA, () => ({
+      id: 'zone-a',
+      onDragEnter: () => events.push('a:enter'),
+      onDragLeave: () => events.push('a:leave'),
+    }));
+
+    dnd.dndDropzone(zoneB, () => ({
+      id: 'zone-b',
+      onDragEnter: () => events.push('b:enter'),
+      onDragLeave: () => events.push('b:leave'),
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    zoneA.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
+    zoneB.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
+
+    expect(events).toEqual(['a:enter', 'a:leave', 'b:enter']);
+  });
+
+  // ── Issue #1: destroy() only fires onDragEnd on active draggable ──
+
+  it('destroy fires onDragEnd only on the active draggable', () => {
+    const draggableA = createEl();
+    const draggableB = createEl();
+
+    const onDragEndA = vi.fn();
+    const onDragEndB = vi.fn();
+
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggableA, () => ({
+      id: 'a',
+      getPayload: () => ({ cardId: 'a' }),
+      onDragEnd: onDragEndA,
+    }));
+
+    dnd.dndDraggable(draggableB, () => ({
+      id: 'b',
+      getPayload: () => ({ cardId: 'b' }),
+      onDragEnd: onDragEndB,
+    }));
+
+    // Start drag on A
+    draggableA.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(dnd.getActiveDrag()).not.toBeNull();
+
+    // Destroy while A is active
+    dnd.destroy();
+
+    expect(onDragEndA).toHaveBeenCalledTimes(1);
+    expect(onDragEndB).not.toHaveBeenCalled();
+  });
+
+  // ── Issue #3: drag threshold ──────────────────────────────────
+
+  it('does not start drag until pointer moves past threshold', () => {
+    const draggable = createEl();
+    const onDragStart = vi.fn();
+
+    const dnd = createDnD<CardPayload>({ dragThreshold: 10 });
+    instances.push(dnd);
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'threshold',
+      getPayload: () => ({ cardId: 'threshold' }),
+      onDragStart,
+    }));
+
+    draggable.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true, clientX: 100, clientY: 100 }),
+    );
+    expect(dnd.getActiveDrag()).toBeNull();
+    expect(onDragStart).not.toHaveBeenCalled();
+
+    // Move less than threshold (5px, need 10)
+    document.dispatchEvent(
+      new MouseEvent('pointermove', { bubbles: true, clientX: 105, clientY: 100 }),
+    );
+    expect(dnd.getActiveDrag()).toBeNull();
+
+    // Move past threshold (11px from start)
+    document.dispatchEvent(
+      new MouseEvent('pointermove', { bubbles: true, clientX: 111, clientY: 100 }),
+    );
+    expect(dnd.getActiveDrag()).not.toBeNull();
+    expect(onDragStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers hover when pointer entered zone before threshold activation', () => {
+    const draggable = createEl();
+    const zone = createEl();
+    const onDrop = vi.fn();
+
+    vi.spyOn(zone, 'getBoundingClientRect').mockReturnValue({
+      x: 300,
+      y: 300,
+      width: 160,
+      height: 140,
+      top: 300,
+      left: 300,
+      right: 460,
+      bottom: 440,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const dnd = createDnD<CardPayload>({ dragThreshold: 10, onDrop });
+    instances.push(dnd);
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'threshold-source',
+      getPayload: () => ({ cardId: 'threshold-recover' }),
+    }));
+
+    dnd.dndDropzone(zone, () => ({
+      id: 'threshold-zone',
+    }));
+
+    draggable.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true, clientX: 100, clientY: 100 }),
+    );
+
+    zone.dispatchEvent(
+      new MouseEvent('pointerenter', { bubbles: true, clientX: 340, clientY: 340 }),
+    );
+
+    document.dispatchEvent(
+      new MouseEvent('pointermove', { bubbles: true, clientX: 340, clientY: 340 }),
+    );
+
+    document.dispatchEvent(
+      new MouseEvent('pointerup', { bubbles: true, clientX: 350, clientY: 350 }),
+    );
+
+    expect(onDrop).toHaveBeenCalledWith(
+      'threshold-zone',
+      expect.objectContaining({
+        sourceId: 'threshold-source',
+        payload: { cardId: 'threshold-recover' },
+        dropPosition: { zoneId: 'threshold-zone', x: 50, y: 50 },
+      }),
+    );
+  });
+
+  it('treats pointerup before threshold as a click (no drag)', () => {
+    const draggable = createEl();
+    const onDragStart = vi.fn();
+    const onInvalidDrop = vi.fn();
+
+    const dnd = createDnD<CardPayload>({ dragThreshold: 10, onInvalidDrop });
+    instances.push(dnd);
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'click',
+      getPayload: () => ({ cardId: 'click' }),
+      onDragStart,
+    }));
+
+    draggable.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true, clientX: 50, clientY: 50 }),
+    );
+
+    // Release without moving past threshold
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+
+    expect(onDragStart).not.toHaveBeenCalled();
+    expect(onInvalidDrop).not.toHaveBeenCalled();
+    expect(dnd.getActiveDrag()).toBeNull();
+  });
+
+  // ── Issue #4: Escape key cancel ───────────────────────────────
+
+  it('cancels active drag on Escape key', () => {
+    const draggable = createEl();
+    const onDragCancel = vi.fn();
+    const onDragEnd = vi.fn();
+
+    const dnd = createTestDnD<CardPayload>({ onDragCancel });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'escape',
+      getPayload: () => ({ cardId: 'escape' }),
+      onDragEnd,
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(dnd.getActiveDrag()).not.toBeNull();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(dnd.getActiveDrag()).toBeNull();
+    expect(onDragCancel).toHaveBeenCalledTimes(1);
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.dnd-preview')).toBeNull();
+  });
+
+  it('Escape without active drag does nothing', () => {
+    const onDragCancel = vi.fn();
+    const dnd = createTestDnD<CardPayload>({ onDragCancel });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(onDragCancel).not.toHaveBeenCalled();
+  });
+
+  // ── Issue #5: lazy global listeners ───────────────────────────
+
+  it('does not have global listeners before a drag starts', () => {
+    const draggable = createEl();
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'lazy',
+      getPayload: () => ({ cardId: 'lazy' }),
+    }));
+
+    // pointermove on document should not do anything (no listeners yet)
+    const onDragStart = vi.fn();
+    dnd.dndDraggable(createEl(), () => ({
+      id: 'lazy2',
+      getPayload: () => ({ cardId: 'lazy2' }),
+      onDragStart,
+    }));
+
+    // Dispatching pointermove/pointerup without starting drag should not throw
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+
+    expect(dnd.getActiveDrag()).toBeNull();
+  });
+
+  it('removes global listeners after drag ends', () => {
+    const draggable = createEl();
+    const onInvalidDrop = vi.fn();
+
+    const dnd = createTestDnD<CardPayload>({ onInvalidDrop });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'listener-cleanup',
+      getPayload: () => ({ cardId: 'cleanup' }),
+    }));
+
+    // Start and end drag
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    onInvalidDrop.mockClear();
+
+    // A second pointerup should NOT trigger the handler (listeners were removed)
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    expect(onInvalidDrop).not.toHaveBeenCalled();
+  });
+
+  // ── Issue #6: configurable previewClassName ───────────────────
+
+  it('uses configured previewClassName', () => {
+    const draggable = createEl();
+
+    const dnd = createTestDnD<CardPayload>({ previewClassName: 'my-ghost' });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'custom-class',
+      getPayload: () => ({ cardId: 'class' }),
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+
+    expect(document.querySelector('.my-ghost')).not.toBeNull();
+    expect(document.querySelector('.dnd-preview')).toBeNull();
+
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+  });
+
+  // ── Issue #11: touch-action ───────────────────────────────────
+
+  it('sets touch-action: none on draggable elements', () => {
+    const draggable = createEl();
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'touch',
+      getPayload: () => ({ cardId: 'touch' }),
+    }));
+
+    expect(draggable.style.touchAction).toBe('none');
+  });
+
+  it('clears touch-action on destroy', () => {
+    const draggable = createEl();
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'touch',
+      getPayload: () => ({ cardId: 'touch' }),
+    }));
+
+    dnd.destroy();
+    expect(draggable.style.touchAction).toBe('');
+  });
+
+  // ── Issue #13: configurable previewZIndex ─────────────────────
+
+  it('applies configured previewZIndex', () => {
+    const draggable = createEl();
+
+    const dnd = createTestDnD<CardPayload>({ previewZIndex: 9999 });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'zindex',
+      getPayload: () => ({ cardId: 'zindex' }),
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+
+    const preview = document.querySelector('.dnd-preview') as HTMLElement;
+    expect(preview?.style.zIndex).toBe('9999');
+
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+  });
+
+  // ── Issue #14: ARIA attributes ────────────────────────────────
+
+  it('sets ARIA attributes on draggable elements', () => {
+    const draggable = createEl();
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'aria',
+      getPayload: () => ({ cardId: 'aria' }),
+    }));
+
+    expect(draggable.getAttribute('aria-roledescription')).toBe('draggable');
+    expect(draggable.getAttribute('aria-grabbed')).toBe('false');
+
+    // Start drag — should set aria-grabbed to true
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(draggable.getAttribute('aria-grabbed')).toBe('true');
+
+    // End drag — should reset to false
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    expect(draggable.getAttribute('aria-grabbed')).toBe('false');
+  });
+
+  it('sets ARIA attributes on dropzone elements', () => {
+    const zone = createEl();
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDropzone(zone, () => ({
+      id: 'aria-zone',
+    }));
+
+    expect(zone.getAttribute('aria-roledescription')).toBe('drop zone');
+  });
+
+  it('removes ARIA attributes on destroy', () => {
+    const draggable = createEl();
+    const zone = createEl();
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'aria-destroy',
+      getPayload: () => ({ cardId: 'aria-destroy' }),
+    }));
+
+    dnd.dndDropzone(zone, () => ({ id: 'zone-aria-destroy' }));
+
+    dnd.destroy();
+
+    expect(draggable.getAttribute('aria-roledescription')).toBeNull();
+    expect(draggable.getAttribute('aria-grabbed')).toBeNull();
+    expect(zone.getAttribute('aria-roledescription')).toBeNull();
+  });
+
+  // ── Issue #2 / #10: per-element directive cleanup ─────────────
+
+  it('cleans up draggable when Solid reactive scope disposes', () => {
+    const draggable = createEl();
+    const dnd = createTestDnD<CardPayload>();
+
+    const dispose = createRoot((_dispose) => {
+      dnd.dndDraggable(draggable, () => ({
+        id: 'cleanup',
+        getPayload: () => ({ cardId: 'cleanup' }),
+      }));
+      return _dispose;
+    });
+
+    // Verify element is functional (can start drag)
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(dnd.getActiveDrag()).not.toBeNull();
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+
+    // Dispose reactive scope — removes listener & map entry
+    dispose();
+
+    // Element should no longer respond to pointerdown
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(dnd.getActiveDrag()).toBeNull();
+  });
+
+  it('cleans up dropzone when Solid reactive scope disposes', () => {
+    const draggable = createEl();
+    const zone = createEl();
+    const onDragEnter = vi.fn();
+
+    const dnd = createTestDnD<CardPayload>();
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'source',
+      getPayload: () => ({ cardId: 'zone-cleanup' }),
+    }));
+
+    const dispose = createRoot((_dispose) => {
+      dnd.dndDropzone(zone, () => ({
+        id: 'target',
+        onDragEnter,
+      }));
+      return _dispose;
+    });
+
+    // Dispose the reactive scope
+    dispose();
+
+    // Start drag, hover over disposed zone — should not fire onDragEnter
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    zone.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
+
+    expect(onDragEnter).not.toHaveBeenCalled();
+
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+  });
+
+  it('resets active drag when the active draggable is cleaned up mid-drag', () => {
+    const draggable = createEl();
+    const onDragEnd = vi.fn();
+
+    const dnd = createTestDnD<CardPayload>();
+
+    const dispose = createRoot((_dispose) => {
+      dnd.dndDraggable(draggable, () => ({
+        id: 'mid-drag-cleanup',
+        getPayload: () => ({ cardId: 'mid' }),
+        onDragEnd,
+      }));
+      return _dispose;
+    });
+
+    // Start drag
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(dnd.getActiveDrag()).not.toBeNull();
+
+    // Dispose while drag is active — should call resetDragState
+    dispose();
+
+    expect(dnd.getActiveDrag()).toBeNull();
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+  });
+
+  // ── pointercancel handling ────────────────────────────────────
+
+  it('cancels active drag on pointercancel', () => {
+    const draggable = createEl();
+    const onDragCancel = vi.fn();
+    const onDragEnd = vi.fn();
+
+    const dnd = createTestDnD<CardPayload>({ onDragCancel });
+
+    dnd.dndDraggable(draggable, () => ({
+      id: 'cancel',
+      getPayload: () => ({ cardId: 'cancel' }),
+      onDragEnd,
+    }));
+
+    draggable.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    expect(dnd.getActiveDrag()).not.toBeNull();
+
+    document.dispatchEvent(new MouseEvent('pointercancel', { bubbles: true }));
+
+    expect(dnd.getActiveDrag()).toBeNull();
+    expect(onDragCancel).toHaveBeenCalledTimes(1);
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/createDnD.ts
@@ -1,0 +1,20 @@
+import { DnDConfig, DnDInstance, DndPayload } from './models';
+import { createDnDContext } from './createDnD.context';
+import { createEventController } from './createDnD.events';
+import { createDraggableDirective } from './createDnD.draggable';
+import { createDropzoneDirective } from './createDnD.dropzone';
+import { createDestroy } from './createDnD.destroy';
+
+export function createDnD<Payload extends DndPayload>(
+	config: DnDConfig<Payload> = {},
+): DnDInstance<Payload> {
+	const context = createDnDContext(config);
+	const events = createEventController(context);
+
+	return {
+		dndDraggable: createDraggableDirective(context, events),
+		dndDropzone: createDropzoneDirective(context, events),
+		getActiveDrag: () => context.state.activeDrag,
+		destroy: createDestroy(context, events),
+	};
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/examples/DropAreaExample.tsx
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/examples/DropAreaExample.tsx
@@ -1,0 +1,200 @@
+import { Component, createSignal, For, onCleanup } from 'solid-js';
+import { createDnD } from '../tools/createDnD';
+
+type DropAreaItem = { id: string; label: string };
+type DropAreaPayload = { item: DropAreaItem; draggedAt: string };
+type DropAreaRecord = {
+	id: string;
+	itemLabel: string;
+	draggedAt: string;
+	droppedX?: number;
+	droppedY?: number;
+};
+type DroppedAreaItem = {
+	id: string;
+	label: string;
+	droppedAt: string;
+	x: number;
+	y: number;
+};
+type DropAreaMoveState = {
+	id: string;
+	offsetX: number;
+	offsetY: number;
+	width: number;
+	height: number;
+};
+
+const dropAreaItems: DropAreaItem[] = [
+	{ id: 'drop-item-1', label: 'Invoice.pdf' },
+	{ id: 'drop-item-2', label: 'Roadmap.md' },
+	{ id: 'drop-item-3', label: 'Design.spec' },
+];
+
+export const DropAreaExample: Component = () => {
+	const [dropAreaLog, setDropAreaLog] = createSignal<DropAreaRecord[]>([]);
+	const [droppedAreaItems, setDroppedAreaItems] = createSignal<DroppedAreaItem[]>([]);
+	const [movingDropItemId, setMovingDropItemId] = createSignal<string | null>(null);
+
+	let dropAreaElement: HTMLDivElement | undefined;
+	let activeDropMove: DropAreaMoveState | null = null;
+
+	const { dndDraggable, dndDropzone, destroy } = createDnD<DropAreaPayload>({
+		onDrop: (_, state) => {
+			const { dropPosition } = state;
+			if (!dropPosition) return;
+			const droppedAt = new Date().toLocaleTimeString();
+			const nextX = dropPosition.x - (state.pointerOffset?.x ?? 0);
+			const nextY = dropPosition.y - (state.pointerOffset?.y ?? 0);
+
+			setDroppedAreaItems((current) => {
+				const nextItem: DroppedAreaItem = {
+					id: `${state.payload.item.id}-${Date.now()}`,
+					label: state.payload.item.label,
+					droppedAt,
+					x: nextX,
+					y: nextY,
+				};
+				return [nextItem, ...current].slice(0, 8);
+			});
+
+			setDropAreaLog((current) => {
+				const nextRecord: DropAreaRecord = {
+					id: `${state.payload.item.id}-${Date.now()}`,
+					itemLabel: state.payload.item.label,
+					draggedAt: state.payload.draggedAt,
+					droppedX: nextX,
+					droppedY: nextY,
+				};
+				return [nextRecord, ...current].slice(0, 6);
+			});
+		},
+	});
+
+	const clamp = (value: number, min: number, max: number) =>
+		max < min ? min : Math.min(Math.max(value, min), max);
+
+	const onDropItemPointerMove = (moveEvent: PointerEvent) => {
+		if (!activeDropMove || !dropAreaElement) return;
+
+		const areaBounds = dropAreaElement.getBoundingClientRect();
+		const nextX = clamp(
+			moveEvent.clientX - areaBounds.left - activeDropMove.offsetX,
+			0,
+			areaBounds.width - activeDropMove.width,
+		);
+		const nextY = clamp(
+			moveEvent.clientY - areaBounds.top - activeDropMove.offsetY,
+			0,
+			areaBounds.height - activeDropMove.height,
+		);
+
+		setDroppedAreaItems((current) =>
+			current.map((item) =>
+				item.id === activeDropMove?.id ? { ...item, x: nextX, y: nextY } : item,
+			),
+		);
+	};
+
+	const detachDropItemMoveListeners = () => {
+		document.removeEventListener('pointermove', onDropItemPointerMove);
+		document.removeEventListener('pointerup', stopMovingDroppedItem);
+		document.removeEventListener('pointercancel', stopMovingDroppedItem);
+	};
+
+	const stopMovingDroppedItem = () => {
+		activeDropMove = null;
+		setMovingDropItemId(null);
+		detachDropItemMoveListeners();
+	};
+
+	const startMovingDroppedItem = (id: string, downEvent: PointerEvent) => {
+		if (!dropAreaElement) return;
+		downEvent.preventDefault();
+		downEvent.stopPropagation();
+
+		const target = downEvent.currentTarget as HTMLElement | null;
+		if (!target) return;
+
+		const itemBounds = target.getBoundingClientRect();
+		activeDropMove = {
+			id,
+			offsetX: downEvent.clientX - itemBounds.left,
+			offsetY: downEvent.clientY - itemBounds.top,
+			width: itemBounds.width,
+			height: itemBounds.height,
+		};
+
+		setMovingDropItemId(id);
+		detachDropItemMoveListeners();
+		document.addEventListener('pointermove', onDropItemPointerMove);
+		document.addEventListener('pointerup', stopMovingDroppedItem);
+		document.addEventListener('pointercancel', stopMovingDroppedItem);
+	};
+
+	onCleanup(() => {
+		stopMovingDroppedItem();
+		destroy();
+	});
+
+	return (
+		<section class="example-panel">
+			<h2 class="example-title">Just drop area example</h2>
+			<div class="drop-example">
+				<div class="drop-source-panel">
+					<h3 class="column-title">Draggable items</h3>
+					<For each={dropAreaItems}>
+						{(item) => (
+							<div
+								class="card"
+								use:dndDraggable={{
+									id: item.id,
+									getPayload: () => ({ item, draggedAt: new Date().toLocaleTimeString() }),
+								}}
+							>
+								{item.label}
+							</div>
+						)}
+					</For>
+				</div>
+
+				<div class="drop-area" ref={dropAreaElement} use:dndDropzone={{ id: 'drop-area' }}>
+					{droppedAreaItems().length === 0 && <div class="drop-area-empty">Drop here</div>}
+					<For each={droppedAreaItems()}>
+						{(item) => (
+							<div
+								class={`card drop-area-card${movingDropItemId() === item.id ? ' is-moving' : ''}`}
+								style={{ left: `${item.x}px`, top: `${item.y}px` }}
+								onPointerDown={(event) => startMovingDroppedItem(item.id, event)}
+							>
+								<span>{item.label}</span>
+								<span>{item.droppedAt}</span>
+							</div>
+						)}
+					</For>
+				</div>
+
+				<div class="transfer-panel drop-log-panel">
+					<h3 class="column-title">Drop history</h3>
+					<For each={dropAreaLog()}>
+						{(entry) => (
+							<div class="transfer-row drop-log-row">
+								<span>{entry.itemLabel}</span>
+								<span>Dropped in area</span>
+								<span>
+									{entry.droppedX !== undefined && entry.droppedY !== undefined
+										? `${Math.round(entry.droppedX)}, ${Math.round(entry.droppedY)}`
+										: 'n/a'}
+								</span>
+								<span>{entry.draggedAt}</span>
+							</div>
+						)}
+					</For>
+					{dropAreaLog().length === 0 && (
+						<div class="transfer-empty">Drop any item in the area to log it.</div>
+					)}
+				</div>
+			</div>
+		</section>
+	);
+};

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/examples/SortableListsExample.tsx
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/examples/SortableListsExample.tsx
@@ -1,0 +1,183 @@
+import { Component, createSignal, For, onCleanup } from 'solid-js';
+import { createDnD } from '../tools/createDnD';
+
+type Card = {
+	id: string;
+	label: string;
+	points: number;
+};
+
+type DragPayload = {
+	card: Card;
+	draggedAt: string;
+};
+
+type ListId = 'zone-1' | 'zone-2';
+type ListsState = Record<ListId, Card[]>;
+
+type TransferRecord = {
+	id: string;
+	cardLabel: string;
+	from: string;
+	to: string;
+	points: number;
+	draggedAt: string;
+};
+
+const listIds: ListId[] = ['zone-1', 'zone-2'];
+
+export const SortableListsExample: Component = () => {
+	const [lists, setLists] = createSignal<ListsState>({
+		'zone-1': [
+			{ id: 'card-1', label: 'Alpha', points: 10 },
+			{ id: 'card-2', label: 'Bravo', points: 20 },
+		],
+		'zone-2': [
+			{ id: 'card-3', label: 'Charlie', points: 30 },
+			{ id: 'card-4', label: 'Delta', points: 40 },
+		],
+	});
+
+	const [transferLog, setTransferLog] = createSignal<TransferRecord[]>([]);
+
+	const { dndDraggable, dndDropzone, destroy } = createDnD<DragPayload>({
+		onDrop: (_, state) => {
+			const sortable = state.sortable;
+
+			if (!sortable?.targetListId || sortable.targetIndex === undefined) {
+				return;
+			}
+
+			setLists((current) => {
+				const sourceListId = sortable.sourceListId as ListId;
+				const targetListId = sortable.targetListId as ListId;
+				const next: ListsState = {
+					'zone-1': [...current['zone-1']],
+					'zone-2': [...current['zone-2']],
+				};
+
+				const sourceCards = next[sourceListId];
+				const targetCards = next[targetListId];
+
+				if (!sourceCards || !targetCards) {
+					return current;
+				}
+
+				const sourceIndex = sourceCards.findIndex(
+					(card) => card.id === state.payload.card.id,
+				);
+
+				if (sourceIndex === -1) {
+					return current;
+				}
+
+				const [movedCard] = sourceCards.splice(sourceIndex, 1);
+				const insertionIndex = Math.max(
+					0,
+					Math.min(sortable.targetIndex, targetCards.length),
+				);
+				targetCards.splice(insertionIndex, 0, movedCard);
+
+				return next;
+			});
+
+			setTransferLog((current) => {
+				const nextRecord: TransferRecord = {
+					id: `${state.payload.card.id}-${Date.now()}`,
+					cardLabel: state.payload.card.label,
+					from: sortable.sourceListId,
+					to: sortable.targetListId,
+					points: state.payload.card.points,
+					draggedAt: state.payload.draggedAt,
+				};
+
+				return [nextRecord, ...current].slice(0, 6);
+			});
+		},
+	});
+
+	onCleanup(() => destroy());
+
+	const createCustomPreview = (label: string) => {
+		const preview = document.createElement('div');
+		preview.className = 'card';
+		preview.textContent = `${label} (custom preview)`;
+		return preview;
+	};
+
+	return (
+		<section class="example-panel">
+			<h2 class="example-title">Sortable lists example</h2>
+
+			<div class="body">
+				<For each={listIds}>
+					{(listId) => (
+						<div class={`column ${listId}`}>
+							<h3 class="column-title">{listId}</h3>
+							<div
+								class="list-start"
+								use:dndDropzone={{
+									id: `${listId}-start`,
+									sortable: { listId, index: 0 },
+								}}
+							>
+								Drop to start
+							</div>
+							<For each={lists()[listId]}>
+								{(item, index) => (
+									<div
+										class="card"
+										use:dndDropzone={{
+											id: `${listId}-${item.id}`,
+											sortable: { listId, index: index() },
+										}}
+										use:dndDraggable={{
+											id: item.id,
+											getPayload: () => ({
+												card: item,
+												draggedAt: new Date().toLocaleTimeString(),
+											}),
+											sortable: { listId, index: index() },
+											createDragPreview: () => createCustomPreview(item.label),
+										}}
+									>
+										{item.label} • {item.points} pts
+									</div>
+								)}
+							</For>
+
+							<div
+								class="list-end"
+								use:dndDropzone={{
+									id: `${listId}-end`,
+									sortable: { listId, index: lists()[listId].length },
+								}}
+							>
+								Drop to end
+							</div>
+						</div>
+					)}
+				</For>
+			</div>
+
+			<div class="transfer-panel">
+				<h3 class="column-title">Payload transfer log</h3>
+				<For each={transferLog()}>
+					{(entry) => (
+						<div class="transfer-row">
+							<span>{entry.cardLabel}</span>
+							<span>
+								{entry.from} → {entry.to}
+							</span>
+							<span>{entry.points} pts</span>
+							<span>{entry.draggedAt}</span>
+						</div>
+					)}
+				</For>
+				{transferLog().length === 0 && (
+					<div class="transfer-empty">Drop a card to capture payload details.</div>
+				)}
+			</div>
+		</section>
+	);
+};

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/models.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/dragNdrop/models.ts
@@ -1,0 +1,140 @@
+/** Base constraint for drag payloads — must be an object. */
+export type DndPayload = object;
+
+/** Coordinates relative to a dropzone's top-left corner. */
+export interface DropzoneCoordinates {
+	zoneId: string;
+	x: number;
+	y: number;
+}
+
+/** Where a sortable item should be inserted relative to a dropzone element. */
+export type SortablePlacement = 'before' | 'after';
+
+/** Sortable metadata carried on a {@link DragState} during a drag operation. */
+export interface SortableDragMeta {
+	sourceListId: string;
+	sourceIndex: number;
+	targetListId?: string;
+	targetIndex?: number;
+	placement?: SortablePlacement;
+}
+
+/** Sortable metadata attached to a draggable binding to identify its list position. */
+export interface SortableDraggableBinding {
+	listId: string;
+	index: number;
+}
+
+/** Sortable metadata attached to a dropzone binding to identify its list position. */
+export interface SortableDropzoneBinding {
+	listId: string;
+	index: number;
+}
+
+/** Snapshot of the current drag operation, passed to all drag/drop callbacks. */
+export interface DragState<Payload extends DndPayload> {
+	sourceId: string;
+	payload: Payload;
+	pointerOffset?: {
+		x: number;
+		y: number;
+	};
+	sortable?: SortableDragMeta;
+	position?: DropzoneCoordinates;
+	dropPosition?: DropzoneCoordinates;
+}
+
+/** Context provided to a custom drag preview factory. */
+export interface DragPreviewContext<Payload extends DndPayload> {
+	state: DragState<Payload>;
+	sourceElement: HTMLElement;
+}
+
+/** Per-element binding for a draggable directive. */
+export interface DraggableBinding<Payload extends DndPayload> {
+	id: string;
+	getPayload: () => Payload;
+	disabled?: boolean;
+	sortable?: SortableDraggableBinding;
+	createDragPreview?: (
+		context: DragPreviewContext<Payload>,
+	) => HTMLElement;
+	onDragStart?: (state: DragState<Payload>) => void;
+	onDragEnd?: (state: DragState<Payload>) => void;
+}
+
+/** Per-element binding for a dropzone directive. */
+export interface DropzoneBinding<Payload extends DndPayload> {
+	id: string;
+	disabled?: boolean;
+	sortable?: SortableDropzoneBinding;
+	accepts?: (state: DragState<Payload>) => boolean;
+	onDrop?: (state: DragState<Payload>) => void;
+	onDragEnter?: (state: DragState<Payload>) => void;
+	onDragLeave?: (state: DragState<Payload>) => void;
+}
+
+/**
+ * Configuration for a {@link createDnD} instance.
+ *
+ * All class-name options default to their `dnd-*` counterparts in CSS.
+ */
+export interface DnDConfig<Payload extends DndPayload> {
+	/** Class added to the active draggable element (default `'dnd-active'`). */
+	activeClassName?: string;
+	/** Class added to the hovered dropzone element (default `'dnd-over'`). */
+	overClassName?: string;
+	/** Class added to the drag preview element (default `'dnd-preview'`). */
+	previewClassName?: string;
+	/** Class for "insert before" sortable indicator (default `'dnd-insert-before'`). */
+	insertBeforeClassName?: string;
+	/** Class for "insert after" sortable indicator (default `'dnd-insert-after'`). */
+	insertAfterClassName?: string;
+	/**
+	 * Minimum pointer movement in pixels before a drag activates (default `5`).
+	 * Set to `0` to activate immediately on pointerdown.
+	 */
+	dragThreshold?: number;
+	/**
+	 * CSS `z-index` applied to the drag preview element (default `1000`).
+	 * Pass a number or string (e.g. `'9999'`).
+	 */
+	previewZIndex?: number | string;
+	/** Called when a drop is accepted by a zone. */
+	onDrop?: (targetId: string, state: DragState<Payload>) => void;
+	/** Called when a drop is rejected or lands outside any zone. */
+	onInvalidDrop?: (state: DragState<Payload>) => void;
+	/** Called when a drag is cancelled via Escape or pointercancel. */
+	onDragCancel?: (state: DragState<Payload>) => void;
+}
+
+/** Public API returned by {@link createDnD}. */
+export interface DnDInstance<Payload extends DndPayload> {
+	dndDraggable: (
+		element: HTMLElement,
+		accessor: () => DraggableBinding<Payload>,
+	) => void;
+	dndDropzone: (
+		element: HTMLElement,
+		accessor: () => DropzoneBinding<Payload>,
+	) => void;
+	getActiveDrag: () => DragState<Payload> | null;
+	destroy: () => void;
+}
+
+/*
+ * Note: The module augmentation below uses the base `DndPayload` type for
+ * `JSX.Directives`. This is a known Solid limitation — the generic narrowing
+ * from `createDnD<MyType>()` does NOT flow through to `use:dndDraggable` in
+ * JSX, so TypeScript won't flag payload type mismatches at the call site.
+ * Runtime behavior is still correct; this only affects static type checking.
+ */
+declare module 'solid-js' {
+	namespace JSX {
+		interface Directives {
+			dndDraggable: DraggableBinding<DndPayload>;
+			dndDropzone: DropzoneBinding<DndPayload>;
+		}
+	}
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/httpClientObs.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/httpClientObs.ts
@@ -128,7 +128,191 @@ class HttpClientObs {
         .catch((err) => observer.error(err));
     });
   }
-}
 
+  public streamText(url: string, options: Omit<RequestInit, 'method'>): Observable<StreamResponse<string>> {
+    return new Observable<StreamResponse<string>>((observer) => {
+      streamText(url, {
+        onChunk: (chunk) => observer.next({ value: chunk }),
+        onError: (err) => observer.error(err),
+        onDone: () => observer.complete(),
+        onProgress: (progress) => observer.next({ value: '', metadata: {
+          percentComplete: progress.percent ?? undefined,
+          totalBytes: progress.totalBytes ?? undefined,
+          receivedBytes: progress.receivedBytes,
+        } }),
+        ...options,
+      })
+    });
+  }
+
+  public fetchJsonWithProgress<T>(url: string, options: Omit<RequestInit, 'method'>): Observable<StreamResponse<T>> {
+    return new Observable<StreamResponse<T>>((observer) => {
+      fetchJsonWithProgress<T>(url, {
+        onProgress: (progress) => observer.next({ value: null as any, metadata: {
+          percentComplete: progress.percent ?? undefined,
+          totalBytes: progress.totalBytes ?? undefined,
+          receivedBytes: progress.receivedBytes,
+        } }),
+        onError: (err) => observer.error(err),
+        ...options,
+      })
+        .then((data) => {
+          observer.next({ value: data });
+          observer.complete();
+        })
+        .catch((err) => observer.error(err));
+    });
+  }
+}
+interface StreamResponse<T> {
+  value: T;
+  metadata?: {
+    percentComplete?: number;
+    totalBytes?: number;
+    receivedBytes?: number;
+  }
+}
 // export a single shared instance
 export default new HttpClientObs();
+
+export type FetchJsonProgress = {
+  receivedBytes: number;
+  totalBytes: number | null;
+  percent: number | null;
+};
+
+type FetchJsonOptions = RequestInit & {
+  onProgress?: (progress: FetchJsonProgress) => void;
+  onError?: (error: unknown) => void;
+};
+
+async function fetchJsonWithProgress<T>(
+  input: RequestInfo | URL,
+  options: FetchJsonOptions = {}
+): Promise<T> {
+  const { onProgress, onError, ...requestInit } = options;
+
+  try {
+    const response = await fetch(input, requestInit);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+
+    if (!response.body) {
+      throw new Error("Response body is empty.");
+    }
+
+    const totalBytesHeader = response.headers.get("Content-Length");
+    const totalBytes = totalBytesHeader ? Number(totalBytesHeader) : null;
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+
+    let receivedBytes = 0;
+    let text = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+
+        receivedBytes += value.byteLength;
+        text += decoder.decode(value, { stream: true });
+
+        onProgress?.({
+          receivedBytes,
+          totalBytes,
+          percent:
+            totalBytes && totalBytes > 0
+              ? Math.min(100, (receivedBytes / totalBytes) * 100)
+              : null,
+        });
+      }
+
+      text += decoder.decode();
+
+      return JSON.parse(text) as T;
+    } finally {
+      reader.releaseLock();
+    }
+  } catch (error) {
+    onError?.(error);
+    throw error;
+  }
+}
+
+export type StreamProgress = {
+  receivedBytes: number;
+  totalBytes: number | null;
+  percent: number | null;
+};
+
+type StreamTextOptions = RequestInit & {
+  onChunk: (chunk: string) => void;
+  onProgress?: (progress: StreamProgress) => void;
+  onDone?: () => void;
+  onError?: (error: unknown) => void;
+};
+
+async function streamText(
+  input: RequestInfo | URL,
+  options: StreamTextOptions
+): Promise<void> {
+  const { onChunk, onProgress, onDone, onError, ...requestInit } = options;
+
+  try {
+    const response = await fetch(input, requestInit);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+
+    if (!response.body) {
+      throw new Error("Response body is empty or streaming is unsupported.");
+    }
+
+    const totalBytesHeader = response.headers.get("Content-Length");
+    const totalBytes = totalBytesHeader ? Number(totalBytesHeader) : null;
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+
+    let receivedBytes = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+
+        receivedBytes += value.byteLength;
+
+        const chunk = decoder.decode(value, { stream: true });
+        if (chunk) onChunk(chunk);
+
+        onProgress?.({
+          receivedBytes,
+          totalBytes,
+          percent:
+            totalBytes && totalBytes > 0
+              ? Math.min(100, (receivedBytes / totalBytes) * 100)
+              : null,
+        });
+      }
+
+      const tail = decoder.decode();
+      if (tail) {
+        onChunk(tail);
+      }
+
+      onDone?.();
+    } finally {
+      reader.releaseLock();
+    }
+  } catch (error) {
+    onError?.(error);
+    throw error;
+  }
+}

--- a/SolidCharacters/client/src/shared/customHooks/utility/tools/idGen.ts
+++ b/SolidCharacters/client/src/shared/customHooks/utility/tools/idGen.ts
@@ -1,3 +1,8 @@
 export function createNewId(): string {
-    return crypto.randomUUID();
+    const uniqueId = crypto.randomUUID();
+    if (uniqueId) {
+        return uniqueId;
+    }
+    // Fallback to a simple random string if crypto.randomUUID is not supported
+    return `${Date.now()}-${Math.random().toString(36)}`;
 }


### PR DESCRIPTION
This pull request introduces a new, reusable AI chat helper hook (`createLLM`) for SolidJS, providing a clean abstraction for integrating large language model (LLM) chat functionality into the UI. It also adds a full example chat component and implements a modular, extensible drag-and-drop (DnD) utility with clear context management, directives for draggables and dropzones, and robust cleanup logic. Additionally, it removes unnecessary debug logs from the JSON download utility.

The most important changes are:

### AI Chat Helper and Example

* Added `createLLM` utility in `aiHelpers.ts`, providing a composable SolidJS hook for LLM chat with support for streaming, error handling, message history, and easy UI integration.
* Added a sample `Chat` component in `aiExample.tsx` demonstrating how to use `createLLM`, including best-practice comments about abort support, token counting, retries, and API key safety.

### Drag-and-Drop Utility

* Implemented `createDnD.context.ts` to define DnD context, types, and a factory for context creation, supporting configuration and state management for draggables and dropzones.
* Added `createDnD.draggable.ts` and `createDnD.dropzone.ts` to provide SolidJS directives for making elements draggable and droppable, including setup, event handling, and cleanup logic. [[1]](diffhunk://#diff-44d89be88a2078406651443cb4966d97743e8a9e686686e963b4b2747213bb05R1-R64) [[2]](diffhunk://#diff-e6aeff774879118be04326385a6ae039900d0dbc56db9473556ac198fe3afd2dR1-R90)
* Added `createDnD.destroy.ts` for comprehensive cleanup of DnD state and event listeners, ensuring no memory leaks or lingering state.

### Utility Cleanup

* Removed unnecessary `console.log` statements from `downloadObjectAsJson.ts` to clean up the codebase.
* Added Streaming to HttpObs
* added DnD5e Math Utilities